### PR TITLE
test launch files and add missing dependencies 

### DIFF
--- a/prbt_moveit_config/CHANGELOG.rst
+++ b/prbt_moveit_config/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog for package prbt_moveit_config
 Forthcoming
 -----------
 * Add <url> tag to all package.xml files
+* test launch files and add missing dependencies
 
 0.2.0 (2018-07-12)
 ------------------

--- a/prbt_moveit_config/CMakeLists.txt
+++ b/prbt_moveit_config/CMakeLists.txt
@@ -8,3 +8,8 @@ catkin_package()
 install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
   PATTERN "setup_assistant.launch" EXCLUDE)
 install(DIRECTORY config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch/moveit_planning_execution.launch)
+endif()

--- a/prbt_moveit_config/launch/move_group.launch
+++ b/prbt_moveit_config/launch/move_group.launch
@@ -60,8 +60,6 @@
 
     <!-- load these non-default MoveGroup capabilities -->
     <param name="capabilities" value="
-                  pilz_trajectory_generation/MoveGroupBlendAction
-                  pilz_trajectory_generation/MoveGroupBlendService
                   " />
 
     <!-- inhibit these default MoveGroup capabilities -->

--- a/prbt_moveit_config/package.xml
+++ b/prbt_moveit_config/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
 
   <name>prbt_moveit_config</name>
   <version>0.2.0</version>
@@ -16,21 +16,23 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>moveit_ros_move_group</run_depend>
-  <run_depend>moveit_kinematics</run_depend>
-  <run_depend>moveit_planners_ompl</run_depend>
-  <run_depend>moveit_ros_visualization</run_depend>
-  <run_depend>moveit_fake_controller_manager</run_depend>
-  <run_depend>moveit_simple_controller_manager</run_depend>
-  <run_depend>ros_control</run_depend>
-  <run_depend>ros_controllers</run_depend>
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>xacro</run_depend>
+  <exec_depend>moveit_ros_move_group</exec_depend>
+  <exec_depend>moveit_kinematics</exec_depend>
+  <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>moveit_fake_controller_manager</exec_depend>
+  <exec_depend>moveit_simple_controller_manager</exec_depend>
+  <exec_depend>ros_control</exec_depend>
+  <exec_depend>ros_controllers</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <exec_depend>rviz</exec_depend>
   <!-- This package is referenced in the warehouse launch files, but does not build out of the box at the moment. Commented the dependency until this works. -->
   <!-- <run_depend>warehouse_ros_mongo</run_depend> -->
-  <build_depend>prbt_support</build_depend>
-  <run_depend>prbt_support</run_depend>
 
+  <depend>prbt_support</depend>
+
+  <test_depend>roslaunch</test_depend>
 
 </package>

--- a/prbt_support/CHANGELOG.rst
+++ b/prbt_support/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog for package prbt_support
 Forthcoming
 -----------
 * Add <url> tag to all package.xml files
+* test launch files and add missing dependencies
 
 0.2.0 (2018-07-12)
 ------------------

--- a/prbt_support/CMakeLists.txt
+++ b/prbt_support/CMakeLists.txt
@@ -47,5 +47,8 @@ if(CATKIN_ENABLE_TESTING)
     ${moveit_ros_planning_LIBRARIES}
     ${Eigen3_LIBRARIES})
 
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch)
+
 endif()
 

--- a/prbt_support/launch/robot.launch
+++ b/prbt_support/launch/robot.launch
@@ -34,9 +34,6 @@
   <!-- Initialize controllers -->
   <node pkg="rosservice" type="rosservice" name="robot_init" args="call --wait /prbt/driver/init"/>
 
-  <!-- Start auto recover node -->
-  <node ns="prbt" pkg="prbt_hardware_support" type="auto_recover_node.py" name="auto_recover_node" />
-
 </launch>
 
 

--- a/prbt_support/package.xml
+++ b/prbt_support/package.xml
@@ -20,14 +20,16 @@
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>schunk_description</exec_depend>
-  <exec_depend>urdf</exec_depend>
+  <exec_depend>topic_tools</exec_depend>
+  <exec_depend>rosservice</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>rviz</exec_depend>
-  
+  <exec_depend>controller_manager</exec_depend>
+
   <test_depend>rostest</test_depend>
   <test_depend>moveit_core</test_depend>
   <test_depend>moveit_kinematics</test_depend>
   <test_depend>cmake_modules</test_depend>
   <test_depend>eigen</test_depend>
-
+  <test_depend>roslaunch</test_depend>
 </package>


### PR DESCRIPTION
The launch file now starts without errors and has all its dependencies declared:
`roslaunch prbt_moveit_config moveit_planning_execution.launch sim:=false pipeline:=ompl has_gripper:=false`