### PR TITLE
Add <url> tag to all package.xml files

### DIFF
--- a/pilz_robots/CHANGELOG.rst
+++ b/pilz_robots/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog for package pilz_robots
 
 Forthcoming
 -----------
+* Add <url> tag to all package.xml files
 * update readme
 
 0.2.0 (2018-07-12)

--- a/pilz_robots/package.xml
+++ b/pilz_robots/package.xml
@@ -9,6 +9,10 @@
 
   <license>Apache 2.0</license>
 
+  <url type="website">https://wiki.ros.org/pilz_robots</url>
+  <url type="bugtracker">https://github.com/PilzDE/pilz_robots/issues</url>
+  <url type="repository">https://github.com/PilzDE/pilz_robots</url>
+
   <buildtool_depend>catkin</buildtool_depend>
 
   <exec_depend>prbt_support</exec_depend>

--- a/prbt_ikfast_manipulator_plugin/CHANGELOG.rst
+++ b/prbt_ikfast_manipulator_plugin/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog for package prbt_ikfast_manipulator_plugin
 
 Forthcoming
 -----------
+* Add <url> tag to all package.xml files
 
 0.2.0 (2018-07-12)
 ------------------

--- a/prbt_ikfast_manipulator_plugin/package.xml
+++ b/prbt_ikfast_manipulator_plugin/package.xml
@@ -9,6 +9,10 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <url type="website">https://wiki.ros.org/prbt_ikfast_manipulator_plugin</url>
+  <url type="bugtracker">https://github.com/PilzDE/pilz_robots/issues</url>
+  <url type="repository">https://github.com/PilzDE/pilz_robots</url>
+
   <export>
     <moveit_core plugin="${prefix}/prbt_manipulator_moveit_ikfast_plugin_description.xml"/>
   </export>

--- a/prbt_moveit_config/CHANGELOG.rst
+++ b/prbt_moveit_config/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog for package prbt_moveit_config
 
 Forthcoming
 -----------
+* Add <url> tag to all package.xml files
 
 0.2.0 (2018-07-12)
 ------------------

--- a/prbt_moveit_config/package.xml
+++ b/prbt_moveit_config/package.xml
@@ -10,9 +10,9 @@
 
   <license>Apache 2.0</license>
 
-  <url type="website">http://moveit.ros.org/</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit</url>
+  <url type="website">https://wiki.ros.org/prbt_moveit_config</url>
+  <url type="bugtracker">https://github.com/PilzDE/pilz_robots/issues</url>
+  <url type="repository">https://github.com/PilzDE/pilz_robots</url>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/prbt_support/CHANGELOG.rst
+++ b/prbt_support/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog for package prbt_support
 
 Forthcoming
 -----------
+* Add <url> tag to all package.xml files
 
 0.2.0 (2018-07-12)
 ------------------

--- a/prbt_support/package.xml
+++ b/prbt_support/package.xml
@@ -8,6 +8,10 @@
 
   <license>Apache 2.0</license>
 
+  <url type="website">https://wiki.ros.org/prbt_support</url>
+  <url type="bugtracker">https://github.com/PilzDE/pilz_robots/issues</url>
+  <url type="repository">https://github.com/PilzDE/pilz_robots</url>
+
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <exec_depend>roscpp</exec_depend>


### PR DESCRIPTION
Since the wiki pages are updated from the package.xml tags:

  - <url type="website">
  - <url type="bugtracker">
  - <url type="repository">

they should exist.

Seems also to be used in the links inside
http://repositories.ros.org/status_page/