### PR TITLE
Avoid constant collisions by namespacing them

### DIFF
--- a/prbt_support/urdf/prbt_macro.xacro
+++ b/prbt_support/urdf/prbt_macro.xacro
@@ -17,20 +17,19 @@ limitations under the License.
 -->
 
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-
-  <!-- Height of Foot -->
-  <xacro:property name="L0" value="0.2604" />
-
-  <!-- Length of the first connector -->
-  <xacro:property name="L1" value="0.3500" />
-
-  <!-- Length of the second connector -->
-  <xacro:property name="L2" value="0.3070" />
-
-  <!-- Distance last joint to flange -->
-  <xacro:property name="L3" value="0.0840" />
-
   <xacro:macro name="prbt" params="prefix">
+
+    <!-- Height of Foot -->
+    <xacro:property name="L0" value="0.2604" />
+
+    <!-- Length of the first connector -->
+    <xacro:property name="L1" value="0.3500" />
+
+    <!-- Length of the second connector -->
+    <xacro:property name="L2" value="0.3070" />
+
+    <!-- Distance last joint to flange -->
+    <xacro:property name="L3" value="0.0840" />
 
     <!-- robot foot link -->
     <link name="${prefix}base_link">


### PR DESCRIPTION
As per subject.

Defining constants inside macros automatically namespaces them, which avoids collisions with other xacro macros that happen to define constants with the same name (and `Ln` is rather generic, so the chance of that happening is rather high).
