### PR TITLE
Add inertial tag to base_link

### DIFF
--- a/prbt_support/urdf/prbt_macro.xacro
+++ b/prbt_support/urdf/prbt_macro.xacro
@@ -33,6 +33,11 @@ limitations under the License.
 
     <!-- robot foot link -->
     <link name="${prefix}base_link">
+      <inertial>
+        <mass value="5"/>
+        <inertia ixx="0"  ixy="0"  ixz="0" iyy="0" iyz="0" izz="0" />
+      </inertial>
+        
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>


### PR DESCRIPTION
The `<inertial>` tag on the `base_link` is required to use the model with MoveIt! and Gazebo.
The provided `mass value` is a rough guess.

Otherwise `gazebo_ros_control` fails with the following error:
```
[ INFO] [1536068104.372075788]: gazebo_ros_control plugin is waiting for model URDF in parameter [/robot_description] on the ROS param server.
[ERROR] [1536068104.507384025]: This robot has a joint named "prbt_joint_1" which is not in the gazebo model.
[FATAL] [1536068104.507615381]: Could not initialize robot simulation interface
```