### PR TITLE
add capabilities argument to moveit_planning_execution

### DIFF
--- a/prbt_moveit_config/CHANGELOG.rst
+++ b/prbt_moveit_config/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package prbt_moveit_config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* add capabilities argument to moveit_planning_execution.launch
+* Contributors: Pilz GmbH and Co. KG
+
 0.3.0 (2018-08-15)
 ------------------
 * remove dependency on gripper

--- a/prbt_moveit_config/launch/moveit_planning_execution.launch
+++ b/prbt_moveit_config/launch/moveit_planning_execution.launch
@@ -32,15 +32,16 @@ limitations under the License.
   <arg name="sim" default="true" />
   <arg name="robot_ip" unless="$(arg sim)" />
 
-  <!-- Choose planning pipeline -->
-  <arg name="pipeline" default="ompl" />
-
   <!-- Set gripper -->
   <arg name="gripper" default="" />
- 
 
   <!-- Load robot description to parameter server. Can be set to false to let someone else load the model -->
   <arg name="load_robot_description" default="true" />
+
+  <!-- configuration for moveit -->
+  <arg name="pipeline" default="ompl" /><!-- Choose planning pipeline -->
+  <arg name="capabilities" default=""/> <!-- define capabilites that are loaded on start (space seperated) -->
+  <arg name="disable_capabilities" default=""/> <!-- inhibit capabilites (space seperated) -->
 
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find prbt_moveit_config)/launch/planning_context.launch" >
@@ -76,6 +77,8 @@ limitations under the License.
     <arg name="pipeline" value="$(arg pipeline)" />
     <arg name="gripper" value="$(arg gripper)" />
     <arg name="load_robot_description" value="$(arg load_robot_description)" />
+    <arg name="capabilities" value="$(arg capabilities)" />
+    <arg name="disable_capabilities" value="$(arg disable_capabilities)" />
   </include>
 
   <include file="$(find prbt_moveit_config)/launch/moveit_rviz.launch">


### PR DESCRIPTION
main launch file passes the options on to move_group.launch

This allows the user, to include moveit_planning_execution.launch with
his custom application robot model to load a specific capability.