### PR TITLE
<gazebo> tag needs to be outside macro

### DIFF
--- a/prbt_support/urdf/prbt_macro.xacro
+++ b/prbt_support/urdf/prbt_macro.xacro
@@ -368,13 +368,12 @@ limitations under the License.
       </joint>
       <actuator name="${prefix}joint_6_motor"/>
     </transmission>
-
-    <gazebo>
-      <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so" >
-        <robotNamespace>prbt</robotNamespace>
-      </plugin>
-    </gazebo>
-
   </xacro:macro>
+
+  <gazebo>
+    <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so" >
+      <robotNamespace>prbt</robotNamespace>
+    </plugin>
+  </gazebo>
 
 </robot>


### PR DESCRIPTION
The robot does not show up in Gazebo if the <gazebo> tag is inside the macro.