### PR TITLE
Fix/modbus read client test

### DIFF
--- a/prbt_hardware_support/include/prbt_hardware_support/pilz_modbus_read_client.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/pilz_modbus_read_client.h
@@ -76,8 +76,6 @@ public:
    * In order for clients to differentiate between messages notifying about
    * changes in the register the timestamp of the message is only changed
    * if a register value changed.
-   *
-   * @return Immediatly returns false if it could not run. Otherwise blocks and returns true if stopped.
    */
   void run();
 

--- a/prbt_hardware_support/test/unittests/unittest_pilz_modbus_read_client.cpp
+++ b/prbt_hardware_support/test/unittests/unittest_pilz_modbus_read_client.cpp
@@ -233,11 +233,9 @@ TEST_F(PilzModbusReadClientTests, terminateRunningClient)
   EXPECT_CALL(*mock, init(_,_))
     .Times(1)
     .WillOnce(Return(true));
-  EXPECT_CALL(*mock, readHoldingRegister(_,_)).WillRepeatedly(Return(std::vector<uint16_t>{3, 4}));
-  EXPECT_CALL(*this, modbus_read_cb(IsSuccessfullRead(std::vector<uint16_t>{3,4})))
-    .WillOnce(ACTION_OPEN_BARRIER_VOID("reading_successful"))
-    .WillRepeatedly(Return());
-  EXPECT_CALL(*this, modbus_read_cb(IsDisconnect())).Times(0);
+  ON_CALL(*mock, readHoldingRegister(_,_)).WillByDefault(Return(std::vector<uint16_t>{3, 4}));
+  ON_CALL(*this, modbus_read_cb(IsSuccessfullRead(std::vector<uint16_t>{3,4})))
+    .WillByDefault(Return());
 
   auto client = std::make_shared< PilzModbusReadClient >(nh_,REGISTER_SIZE_TEST,REGISTER_FIRST_IDX_TEST,std::move(mock));
 


### PR DESCRIPTION
This fixes a failing `EXPECT_TRUE(client->isRunning());` due to missing synchronization.