### PR TITLE
add dependency moveit_config->prbt_ikfast

### DIFF
--- a/prbt_moveit_config/CMakeLists.txt
+++ b/prbt_moveit_config/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(prbt_moveit_config)
 
-find_package(catkin REQUIRED COMPONENTS prbt_support)
+find_package(catkin REQUIRED COMPONENTS prbt_support prbt_ikfast_manipulator_plugin)
 
 catkin_package()
 

--- a/prbt_moveit_config/package.xml
+++ b/prbt_moveit_config/package.xml
@@ -32,6 +32,7 @@
   <!-- <run_depend>warehouse_ros_mongo</run_depend> -->
 
   <depend>prbt_support</depend>
+  <depend>prbt_ikfast_manipulator_plugin</depend>
 
   <test_depend>roslaunch</test_depend>
 


### PR DESCRIPTION
The launch files in moveit_config set the ikfast plugin as kinematics solver
so adding a depend to install the package.