### PR TITLE
Add missing <build_depend> on roscpp

### DIFF
--- a/pilz_testutils/package.xml
+++ b/pilz_testutils/package.xml
@@ -13,4 +13,6 @@
   <url type="repository">https://github.com/PilzDE/pilz_robots</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>roscpp</build_depend>
 </package>


### PR DESCRIPTION
Needed since binary jobs are failing on the buildfarm due to missing <build_depend>