### PR TITLE
Use blank.world in gazebo integrationtest

### DIFF
--- a/prbt_gazebo/launch/sim_prbt_gazebo.launch
+++ b/prbt_gazebo/launch/sim_prbt_gazebo.launch
@@ -31,6 +31,7 @@ limitations under the License.
     <arg name="paused" value="$(arg paused)"/>
     <arg name="use_sim_time" value="$(arg use_sim_time)"/>
     <arg name="headless" value="$(arg headless)"/>
+    <arg name="world_name" value="worlds/blank.world"/>
   </include>
 
   <!-- Load the URDF into the ROS Parameter Server -->


### PR DESCRIPTION
* Targets #70
* Some errors where observered trying to load models (e.g. sun) when running
  in travis. With this change the integrationtest loads the blank.world which
  has no models.