### PR TITLE
update the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ The meta package for the PILZ manipulator PRBT 6. Here you can find documentatio
 
 ![PRBT manipulator](prbt_support/img/prbt.jpg)
 
+### Installation
+To use the packages, you can install prebuilt packages with
+```
+sudo apt install ros-kinetic-pilz-robots
+or
+sudo apt install ros-melodic-pilz-robots
+```
+
 ### Build Status
 
 | Kinetic | Melodic |
@@ -58,8 +66,16 @@ The launch file allows to set optional parameters
     false: connect to real robot using `ros_canopen`
 * `pipeline` (default: ompl) <br>
     Planning pipeline to use with moveit
+* `load_robot_description` (default: True)<br>
+    Load robot description to parameter server. Can be set to false to let someone else load the model
+* `rviz_default` (default: True)<br>
+    Start RViz with default configuration settings. Set this to `False` once you have changed the configuration and have saved it as default.
 * `gripper` (default: None) <br>
     See [Running the prbt with a gripper](#running-the-prbt-with-a-gripper)
+* `sto` (default: pnoz)<br>
+    Connect to the safety controller that handles the safe-torque-off signal. 
+	Only relevant for `sim:=False` to issue a Safe stop 1.
+	See [prbt_hardware_support package](prbt_hardware_support/README.md).
 
 ### Running the simulation
 1. Run `roslaunch prbt_moveit_config moveit_planning_execution.launch sim:=true pipeline:=ompl`
@@ -81,9 +97,15 @@ iface can0 can static
 
 Instead of OMPL use the motion planners of Pilz for executing industrial robot commands like PTP, LIN, etc. For this install the
 package [pilz_trajectory_generation](http://wiki.ros.org/pilz_trajectory_generation):
-* `sudo apt-get install ros-kinetic-pilz-trajectory-generation`
+* `sudo apt install ros-kinetic-pilz-trajectory-generation`
 
 then replace the pipeline in the above command by `pipeline:=pilz_command_planner`.
+
+### Adjust expert paramters
+If you've created an application package with your own launch file as described in the
+[tutorials](https://wiki.ros.org/pilz_robots/Tutorials/ModelYourApplicationWithPRBT#Create_your_application_ROS_package),
+you can easily adjust many other configuration parameters.
+See the template and comments in the [pilz_tutorials package](https://github.com/PilzDE/pilz_tutorials).
 
 ### Running the prbt with a gripper
 Currently only the Schunk pg70 is supported. To run it, first install the package:

--- a/prbt_hardware_support/README.md
+++ b/prbt_hardware_support/README.md
@@ -1,6 +1,8 @@
 # Overview
 The prbt_hardware_support package contains files needed to control hardware functions of the PRBT manipulator like STO for Stop1 functionality. The Pilz hardware PNOZmulti is supported using a Modbus connection.
 
+There is no need to call these launch files directly; they are included from `prbt_support/robot.launch`.
+
 # Safe stop 1 (SS1)
 The STO function (“Safe torque off”) of the robot arm is a safety function to immediately turn off torque of the drives. To allow a
 controlled stop, the safety controller is allowed to delay the STO signal by several milliseconds. This package opens a

--- a/prbt_moveit_config/launch/moveit_planning_execution.launch
+++ b/prbt_moveit_config/launch/moveit_planning_execution.launch
@@ -28,9 +28,7 @@ limitations under the License.
   <rosparam command="load" file="$(find prbt_moveit_config)/config/joint_names.yaml"/>
  
   <!-- the "sim" argument controls whether we connect to a Simulated or Real robot -->
-  <!--  - if sim=false, a robot_ip argument is required -->
   <arg name="sim" default="true" />
-  <arg name="robot_ip" unless="$(arg sim)" />
 
   <!-- Set gripper -->
   <arg name="gripper" default="" />
@@ -40,6 +38,9 @@ limitations under the License.
  
   <!-- Load robot description to parameter server. Can be set to false to let someone else load the model -->
   <arg name="load_robot_description" default="true" />
+
+  <!-- Start RViz with default configuration settings. Set this to false once you have changed the configuration and have saved it as default. -->
+  <arg name="rviz_default" default="true" />
 
   <!-- configuration for moveit -->
   <arg name="pipeline" default="ompl" /><!-- Choose planning pipeline -->
@@ -65,8 +66,7 @@ limitations under the License.
   </group>
 
   <!-- run the "real robot" interface nodes -->
-  <!--   - this typically includes: robot_state, motion_interface, and joint_trajectory_action nodes -->
-  <!--   - replace these calls with appropriate robot-specific calls or launch files -->
+  <!--   - this includes: robot_state, canopen, and sto nodes -->
   <group unless="$(arg sim)">
     <include file="$(find prbt_support)/launch/robot.launch" >
       <arg name="gripper" value="$(arg gripper)" />
@@ -86,7 +86,7 @@ limitations under the License.
   </include>
 
   <include file="$(find prbt_moveit_config)/launch/moveit_rviz.launch">
-    <arg name="config" value="true"/>
+    <arg name="config" value="$(arg rviz_default)"/>
   </include>
 
 </launch>


### PR DESCRIPTION
* add missing launch file parameters
* rviz_default parameter avoids resetting to the default rviz config at
  every start (or have to clone the repository to make this change)
* reference the launch file template in the tutorials repo. Closes #72.

This adds documentation to the paramters introduced in d0c9fd432c4e475947410940db4667353501d8a9.