### PR TITLE
pass rviz config file path as launch argument

### DIFF
--- a/prbt_moveit_config/launch/demo.launch
+++ b/prbt_moveit_config/launch/demo.launch
@@ -1,5 +1,8 @@
 <launch>
+
+  <!-- specify the planning pipeline -->
   <arg name="pipeline" default="ompl" />
+
   <!-- By default, we do not start a database (it can be large) -->
   <arg name="db" default="false" />
   <!-- Allow user to specify database location -->
@@ -7,6 +10,16 @@
 
   <!-- By default, we are not in debug mode -->
   <arg name="debug" default="false" />
+
+  <!--
+  By default, hide joint_state_publisher's GUI
+
+  MoveIt!'s "demo" mode replaces the real robot driver with the joint_state_publisher.
+  The latter one maintains and publishes the current joint configuration of the simulated robot.
+  It also provides a GUI to move the simulated robot around "manually".
+  This corresponds to moving around the real robot without the use of MoveIt.
+  -->
+  <arg name="use_gui" default="false" />
 
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
   <include file="$(find prbt_moveit_config)/launch/planning_context.launch">
@@ -18,14 +31,14 @@
 
   <!-- We do not have a robot connected, so publish fake joint states -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="/use_gui" value="false"/>
-    <rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam>
+    <param name="use_gui" value="$(arg use_gui)"/>
+    <rosparam param="source_list">[move_group/fake_controller_joint_states]</rosparam>
   </node>
 
   <!-- Given the published joint states, publish tf for the robot links -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
-  <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
+  <!-- Run the main MoveIt! executable without trajectory execution (we do not have controllers configured by default) -->
   <include file="$(find prbt_moveit_config)/launch/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
@@ -36,7 +49,7 @@
 
   <!-- Run Rviz and load the default config to see the state of the move_group node -->
   <include file="$(find prbt_moveit_config)/launch/moveit_rviz.launch">
-    <arg name="config" value="true"/>
+    <arg name="rviz_config" value="$(find prbt_moveit_config)/launch/moveit.rviz"/>
     <arg name="debug" value="$(arg debug)"/>
   </include>
 

--- a/prbt_moveit_config/launch/moveit_planning_execution.launch
+++ b/prbt_moveit_config/launch/moveit_planning_execution.launch
@@ -39,8 +39,9 @@ limitations under the License.
   <!-- Load robot description to parameter server. Can be set to false to let someone else load the model -->
   <arg name="load_robot_description" default="true" />
 
-  <!-- Start RViz with default configuration settings. Set this to false once you have changed the configuration and have saved it as default. -->
-  <arg name="rviz_default" default="true" />
+  <!-- Start RViz with default configuration settings. Once you have changed the configuration and have saved
+       it inside your package folder, set the path and file name here. -->
+  <arg name="rviz_config" default="$(find prbt_moveit_config)/launch/moveit.rviz" />
 
   <!-- configuration for moveit -->
   <arg name="pipeline" default="ompl" /><!-- Choose planning pipeline -->
@@ -86,7 +87,7 @@ limitations under the License.
   </include>
 
   <include file="$(find prbt_moveit_config)/launch/moveit_rviz.launch">
-    <arg name="config" value="$(arg rviz_default)"/>
+    <arg name="rviz_config" value="$(arg rviz_config)"/>
   </include>
 
 </launch>

--- a/prbt_moveit_config/launch/moveit_rviz.launch
+++ b/prbt_moveit_config/launch/moveit_rviz.launch
@@ -4,10 +4,10 @@
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
   <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
 
-  <arg name="config" default="false" />
-  <arg unless="$(arg config)" name="command_args" value="" />
-  <arg     if="$(arg config)" name="command_args" value="-d $(find prbt_moveit_config)/launch/moveit.rviz" />
-  
+  <arg name="rviz_config" default="" />
+  <arg     if="$(eval rviz_config=='')" name="command_args" value="" />
+  <arg unless="$(eval rviz_config=='')" name="command_args" value="-d $(arg rviz_config)" />
+
   <node name="$(anon rviz)" launch-prefix="$(arg launch_prefix)" pkg="rviz" type="rviz" respawn="false"
 	args="$(arg command_args)" output="screen">
     <rosparam command="load" file="$(find prbt_moveit_config)/config/kinematics.yaml"/>


### PR DESCRIPTION
According to @rfeistenauer it is preferred to hava a rviz-config in
an application package and not just a user-default.
(See https://github.com/ros-planning/moveit/pull/1397)

Re-generated demo.launch from upstream template.