### PR TITLE
Fix test_context.launch in prbt_moveit_config

### DIFF
--- a/prbt_moveit_config/launch/test_context.launch
+++ b/prbt_moveit_config/launch/test_context.launch
@@ -19,11 +19,19 @@
 
   <!-- Load updated joint limits (override information from URDF) -->
   <group ns="$(arg robot_description)_planning">
-    <rosparam command="load" file="$(find prbt_moveit_config)/config/joint_limits.yaml"/>
+    <rosparam if="$(eval not gripper)" command="load" file="$(find prbt_moveit_config)/config/joint_limits.yaml"/>
+    <rosparam unless="$(eval not gripper)" command="load"
+              file="$(eval find('prbt_'+ gripper + '_support') + '/config/joint_limits.yaml')" />
+
+    <!-- Load cartesian limits -->
+    <rosparam command="load" file="$(find prbt_moveit_config)/config/cartesian_limits.yaml"/>
   </group>
 
-  <!-- Load updated joint limits (override information from URDF) -->
-  <group ns="$(arg robot_description)_planning">
+  <!-- Load limits again in default namespace (which may not be configurable for planners) -->
+  <group ns="robot_description_planning">
+    <rosparam if="$(eval not gripper)" command="load" file="$(find prbt_moveit_config)/config/joint_limits.yaml"/>
+    <rosparam unless="$(eval not gripper)" command="load"
+              file="$(eval find('prbt_'+ gripper + '_support') + '/config/joint_limits.yaml')" />
     <rosparam command="load" file="$(find prbt_moveit_config)/config/cartesian_limits.yaml"/>
   </group>
 


### PR DESCRIPTION
* load joint limits of gripper joints
* hotfix: default joint limits namespace for tests with pilz command_planner

I would aim for a release asap such that [pilz_industrial_motion#131](https://github.com/PilzDE/pilz_industrial_motion/pull/131) is not delayed.