### PR TITLE
longer timeout for modbus responses

### DIFF
--- a/prbt_hardware_support/CHANGELOG.rst
+++ b/prbt_hardware_support/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package prbt_hardware_support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* increased modbus response timeout to 20ms
+
 0.5.3 (2019-04-24)
 ------------------
 * cleanup CMakeLists of prbt_hardware_support

--- a/prbt_hardware_support/include/prbt_hardware_support/pilz_modbus_read_client.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/pilz_modbus_read_client.h
@@ -109,7 +109,7 @@ private:
   //! Index from which the registers have to be read.
   const uint32_t INDEX_OF_FIRST_REGISTER;
 
-  static constexpr unsigned int RESPONSE_TIMEOUT_IN_MS {10};
+  static constexpr unsigned int RESPONSE_TIMEOUT_IN_MS {20};
 
   static constexpr double MODBUS_RATE_HZ {500};
 


### PR DESCRIPTION
I tested it with different ethernet adapters: This timeout can always be met.