### PR TITLE
Add gripper brackets definition to prbt.xacro

### DIFF
--- a/prbt_support/CHANGELOG.rst
+++ b/prbt_support/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package prbt_support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Add gripper brackets definition to prbt.xacro
+* Contributors: Pilz GmbH and Co. KG
+
 0.4.7 (2019-02-15)
 ------------------
 * drop outdated can configuration

--- a/prbt_support/urdf/prbt.xacro
+++ b/prbt_support/urdf/prbt.xacro
@@ -56,7 +56,17 @@ limitations under the License.
 
   <!-- If gripper given then... -->
   <xacro:if value="${gripper != ''}">
+    <!-- name of the gripper -->
+    <xacro:arg name="gripper_name" default="$(arg robot_prefix)gripper"/>
+
     <xacro:include filename="$(find prbt_${gripper}_support)/urdf/${gripper}.urdf.xacro" />
+
+    <!-- Add gripper brackets -->
+    <xacro:include filename="$(find prbt_support)/urdf/simple_gripper_brackets.urdf.xacro" />
+    <xacro:simple_gripper_brackets
+        gripper_name="$(arg gripper_name)"
+        parent_left="$(arg gripper_name)_finger_left_link"
+        parent_right="$(arg gripper_name)_finger_right_link"/>
   </xacro:if>
 
 </robot>


### PR DESCRIPTION
Now a user can include custom brackets when he writes an own urdf. This was not possible since the default brackets were included in the gripper (pg70) urdf. Fixes PilzDE/prbt_grippers#6