### PR TITLE
Remove rosparam block no longer needed

### DIFF
--- a/prbt_gazebo/launch/sim_prbt_gazebo.launch
+++ b/prbt_gazebo/launch/sim_prbt_gazebo.launch
@@ -52,11 +52,6 @@ limitations under the License.
   <!-- set pid parameters -->
   <rosparam ns="prbt" command="load" file="$(find prbt_gazebo)/config/gazebo_pid_gains.yaml" />
 
-  <!-- set pid parameters for gazebo7, can be removed with ros-kinetic-gazebo-ros-control 2.5.18
-       when https://github.com/ros-simulation/gazebo_ros_pkgs/pull/637 will be released
-  -->
-  <rosparam command="load" file="$(find prbt_gazebo)/config/gazebo_pid_gains.yaml" />
-
   <!-- ros_control robot launch file -->
   <rosparam ns="prbt" command="load" file="$(find prbt_support)/config/manipulator_controller.yaml" />
   <!-- set the standart controller -->


### PR DESCRIPTION
gazebo-ros-control version is 2.5.18-1
http://repositories.ros.org/status_page/ros_kinetic_default.html?q=gazebo_ros