### PR TITLE
WIP: Generalized modbus client

### DIFF
--- a/prbt_hardware_support/config/modbus_read.yaml
+++ b/prbt_hardware_support/config/modbus_read.yaml
@@ -1,0 +1,8 @@
+modbus_read:
+  index_of_first_register_to_read: 512
+  num_registers_to_read: 2
+  rate_hz: 500
+another_topic:
+  index_of_first_register_to_read: 1024
+  num_registers_to_read: 99
+  rate_hz: 20 

--- a/prbt_hardware_support/include/prbt_hardware_support/param_names.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/param_names.h
@@ -25,10 +25,13 @@ namespace prbt_hardware_support
 
 static const std::string PARAM_MODBUS_SERVER_IP_STR {"modbus_server_ip"};
 static const std::string PARAM_MODBUS_SERVER_PORT_STR {"modbus_server_port"};
-static const std::string PARAM_INDEX_OF_FIRST_REGISTER_TO_READ_STR {"index_of_first_register_to_read"};
-static const std::string PARAM_NUM_REGISTERS_TO_READ_STR {"num_registers_to_read"};
 static const std::string PARAM_MODBUS_CONNECTION_RETRIES {"modbus_connection_retries"};
 static const std::string PARAM_MODBUS_CONNECTION_RETRY_TIMEOUT {"modbus_connection_retry_timeout"};
+
+static const std::string PARAM_CONFIG_NAMESPACE_STR {"topics"};
+static const std::string SUB_PARAM_INDEX_OF_FIRST_REGISTER_TO_READ_STR {"index_of_first_register_to_read"};
+static const std::string SUB_PARAM_NUM_REGISTERS_TO_READ_STR {"num_registers_to_read"};
+static const std::string SUB_PARAM_RATE_HZ_STR {"rate_hz"};
 
 }
 

--- a/prbt_hardware_support/include/prbt_hardware_support/param_names.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/param_names.h
@@ -33,6 +33,9 @@ static const std::string SUB_PARAM_INDEX_OF_FIRST_REGISTER_TO_READ_STR {"index_o
 static const std::string SUB_PARAM_NUM_REGISTERS_TO_READ_STR {"num_registers_to_read"};
 static const std::string SUB_PARAM_RATE_HZ_STR {"rate_hz"};
 
+/* for testing only: */
+static const std::string PARAM_INDEX_OF_FIRST_REGISTER_TO_READ_STR {"index_of_first_register_to_read"};
+static const std::string PARAM_NUM_REGISTERS_TO_READ_STR {"num_registers_to_read"};
 }
 
 #endif // PARAM_NAMES_H

--- a/prbt_hardware_support/include/prbt_hardware_support/pilz_modbus_read_client.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/pilz_modbus_read_client.h
@@ -43,13 +43,14 @@ public:
    * @param ModbusClient to use
    */
   PilzModbusReadClient(ros::NodeHandle& nh,
-                       const unsigned int num_registers_to_read,
+                       const std::string topic,
                        const unsigned int index_of_first_register,
+                       const unsigned int num_registers_to_read,
+                       const unsigned int rate_hz,
                        ModbusClientUniquePtr modbus_client);
 
   ~PilzModbusReadClient(){}
 
-public:
   /**
    * @brief Tries to connect to a modbus server.
    * @param ip
@@ -104,14 +105,16 @@ private:
     running,
   };
 
-  //! Number of registers which have to be read.
-  const uint32_t NUM_REGISTERS_TO_READ;
   //! Index from which the registers have to be read.
   const uint32_t INDEX_OF_FIRST_REGISTER;
 
-  static constexpr unsigned int RESPONSE_TIMEOUT_IN_MS {10};
+  //! Number of registers which have to be read.
+  const uint32_t NUM_REGISTERS_TO_READ;
 
-  static constexpr double MODBUS_RATE_HZ {500};
+  //! Rate at which the registers have to be read.
+  const uint32_t RATE_HZ;
+
+  static constexpr unsigned int RESPONSE_TIMEOUT_IN_MS {10};
 
   static constexpr int DEFAULT_QUEUE_SIZE_MODBUS {1};
 

--- a/prbt_hardware_support/include/prbt_hardware_support/pilz_modbus_read_client.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/pilz_modbus_read_client.h
@@ -43,10 +43,10 @@ public:
    * @param ModbusClient to use
    */
   PilzModbusReadClient(ros::NodeHandle& nh,
-                       const std::string topic,
-                       const unsigned int index_of_first_register,
-                       const unsigned int num_registers_to_read,
-                       const unsigned int rate_hz,
+                       std::string topic,
+                       unsigned int index_of_first_register,
+                       unsigned int num_registers_to_read,
+                       unsigned int rate_hz,
                        ModbusClientUniquePtr modbus_client);
 
   ~PilzModbusReadClient(){}

--- a/prbt_hardware_support/launch/modbus_read_client.launch
+++ b/prbt_hardware_support/launch/modbus_read_client.launch
@@ -20,14 +20,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <!-- PNoz-Multi settings -->
   <arg name="modbus_server_ip" default="169.254.60.1" />
   <arg name="modbus_server_port" default="502" />
-  <arg name="index_of_first_register_to_read" default="512" />
-  <arg name="num_registers_to_read" default="2" />
 
   <node required="true" pkg="prbt_hardware_support" type="pilz_modbus_read_client_node" name="pilz_modbus_read_client_node" output="screen">
     <param name="modbus_server_ip" value="$(arg modbus_server_ip)"/>
     <param name="modbus_server_port" value="$(arg modbus_server_port)"/>
-    <param name="index_of_first_register_to_read" value="$(arg index_of_first_register_to_read)"/>
-    <param name="num_registers_to_read" value="$(arg num_registers_to_read)"/>
+    <rosparam ns="topics" command="load" file="$(find prbt_hardware_support)/config/modbus_read.yaml" />
   </node>
 
 </launch>

--- a/prbt_hardware_support/launch/sto_modbus_adapter_node.launch
+++ b/prbt_hardware_support/launch/sto_modbus_adapter_node.launch
@@ -16,11 +16,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <launch>
-
-  <arg name="index_of_first_register_to_read" default="512" />
-
   <node required="true" ns="prbt" pkg="prbt_hardware_support" type="sto_modbus_adapter_node" name="sto_modbus_adapter_node" output="screen">
-    <param name="index_of_first_register_to_read" value="$(arg index_of_first_register_to_read)"/>
   </node>
-
 </launch>

--- a/prbt_hardware_support/src/pilz_modbus_read_client_node.cpp
+++ b/prbt_hardware_support/src/pilz_modbus_read_client_node.cpp
@@ -71,10 +71,7 @@ int main(int argc, char **argv)
     return EXIT_FAILURE;
   }
 
-
   ROS_DEBUG_STREAM("Modbus client IP: " << ip << " | Port: " << port);
-
-
 
   ROS_DEBUG_STREAM("Config: " << rpc.toXml().c_str());
 

--- a/prbt_hardware_support/test/integrationtests/integrationtest_stop1.cpp
+++ b/prbt_hardware_support/test/integrationtests/integrationtest_stop1.cpp
@@ -168,6 +168,7 @@ TEST_F(Stop1IntegrationTest, testServiceCallbacks)
 
   waitForNode("/pilz_modbus_read_client_node");
   waitForNode("/sto_modbus_adapter_node");
+  ROS_INFO("waited ...");
 
   // We expect:
   {

--- a/prbt_hardware_support/test/integrationtests/integrationtest_stop1.test
+++ b/prbt_hardware_support/test/integrationtests/integrationtest_stop1.test
@@ -31,18 +31,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <arg name="num_registers_to_read" default="2" />
 
 <node name="pilz_modbus_read_client_node" pkg="prbt_hardware_support" type="pilz_modbus_read_client_node">
-  <param name="index_of_first_register_to_read" value="$(arg index_of_first_register_to_read)"/>
   <param name="modbus_server_ip" value="$(arg modbus_server_ip)"/>
   <param name="modbus_server_port" value="$(arg modbus_server_port)"/>
-  <param name="index_of_first_register_to_read" value="$(arg index_of_first_register_to_read)"/>
-  <param name="num_registers_to_read" value="$(arg num_registers_to_read)"/>
+  <rosparam ns="topics" command="load" file="$(find prbt_hardware_support)/config/modbus_read.yaml" />
 </node>
 
 <node name="sto_modbus_adapter_node" pkg="prbt_hardware_support" type="sto_modbus_adapter_node">
   <param name="index_of_first_register_to_read" value="$(arg index_of_first_register_to_read)"/>
 </node>
 
-<test test-name="integrationtest_stop1" pkg="prbt_hardware_support" type="integrationtest_stop1">
+<test test-name="integrationtest_stop1" pkg="prbt_hardware_support" type="integrationtest_stop1" time-limit="10.0">
   <param name="modbus_server_ip" value="$(arg modbus_server_ip)"/>
   <param name="modbus_server_port" value="$(arg modbus_server_port)"/>
   <param name="modbus_register_size" value="$(arg modbus_register_size)"/>

--- a/prbt_hardware_support/test/unittests/pilz_modbus_server_mock.cpp
+++ b/prbt_hardware_support/test/unittests/pilz_modbus_server_mock.cpp
@@ -20,7 +20,7 @@
 #include <prbt_hardware_support/param_names.h>
 #include <prbt_hardware_support/pilz_modbus_server_mock.h>
 
-#include <ros/console.h>
+#include <ros/ros.h>
 
 namespace prbt_hardware_support
 {
@@ -121,7 +121,6 @@ void PilzModbusServerMock::run()
 #endif
 
   uint8_t query[MODBUS_TCP_MAX_ADU_LENGTH];
-
   // Connect to client loop
   while (!terminate_)
   {
@@ -129,21 +128,23 @@ void PilzModbusServerMock::run()
     // Set socket non blocking
     //fcntl(socket_, F_SETFL, O_NONBLOCK);
 
-{
-   std::lock_guard<std::mutex> lk(running_mutex_);
-    running_cv_.notify_one();
-}
+    {
+	    std::lock_guard<std::mutex> lk(running_mutex_);
+	    running_cv_.notify_one();
+    }
 
     ROS_ERROR("Notify");
 
     ROS_DEBUG("Waiting for connection");
     int result {-1};
+
+    while(!ros::isInitialized()){}
+
     while(result < 0)
     {
-      ROS_ERROR("Inside Loop");
       result = modbus_tcp_accept(modbus_connection_, &socket_);
-      ROS_ERROR("modbus_tcp_accept");
-
+      ROS_ERROR("modbus_tcp_accept: %d", result);
+			ros::Duration(0.5).sleep();
       if(terminate_) break;
     }
     ROS_DEBUG_STREAM("Connection with client accepted.");

--- a/prbt_hardware_support/test/unittests/unittest_pilz_modbus_read_client.cpp
+++ b/prbt_hardware_support/test/unittests/unittest_pilz_modbus_read_client.cpp
@@ -47,9 +47,11 @@ using ::testing::InSequence;
 using ::testing::InvokeWithoutArgs;
 using namespace prbt_hardware_support;
 
+static const std::string TOPIC_TEST {"test"};
 static constexpr unsigned int DEFAULT_MODBUS_PORT_TEST {502};
 static constexpr unsigned int REGISTER_FIRST_IDX_TEST {512};
 static constexpr unsigned int REGISTER_SIZE_TEST {2};
+static constexpr unsigned int DEFAULT_RATE_HZ_TEST {500};
 
 static constexpr double WAIT_FOR_START_TIMEOUT_S {3.0};
 static constexpr double WAIT_SLEEPTIME_S {0.1};
@@ -95,7 +97,8 @@ TEST_F(PilzModbusReadClientTests, testInitialization)
       .Times(1)
       .WillOnce(Return(true));
 
-  PilzModbusReadClient client(nh_,REGISTER_SIZE_TEST,REGISTER_FIRST_IDX_TEST,std::move(mock));
+  PilzModbusReadClient client(nh_, TOPIC_TEST, REGISTER_FIRST_IDX_TEST, REGISTER_SIZE_TEST,
+          DEFAULT_RATE_HZ_TEST, std::move(mock));;
 
   EXPECT_TRUE(client.init(LOCALHOST, DEFAULT_MODBUS_PORT_TEST));
 }
@@ -112,7 +115,8 @@ TEST_F(PilzModbusReadClientTests, testInitializationWithRetry)
       .WillOnce(Return(false))
       .WillOnce(Return(true));
 
-  PilzModbusReadClient client(nh_,REGISTER_SIZE_TEST,REGISTER_FIRST_IDX_TEST,std::move(mock));
+  PilzModbusReadClient client(nh_, TOPIC_TEST, REGISTER_FIRST_IDX_TEST, REGISTER_SIZE_TEST,
+          DEFAULT_RATE_HZ_TEST, std::move(mock));;
 
   EXPECT_TRUE(client.init(LOCALHOST, DEFAULT_MODBUS_PORT_TEST, REGISTER_SIZE_TEST, ros::Duration(0.1)));
 }
@@ -128,7 +132,8 @@ TEST_F(PilzModbusReadClientTests, doubleInitialization)
       .Times(1)
       .WillOnce(Return(true));
 
-  PilzModbusReadClient client(nh_,REGISTER_SIZE_TEST,REGISTER_FIRST_IDX_TEST,std::move(mock));
+  PilzModbusReadClient client(nh_, TOPIC_TEST, REGISTER_FIRST_IDX_TEST, REGISTER_SIZE_TEST,
+          DEFAULT_RATE_HZ_TEST, std::move(mock));;
 
   EXPECT_TRUE(client.init(LOCALHOST, DEFAULT_MODBUS_PORT_TEST));
   EXPECT_FALSE(client.init(LOCALHOST, DEFAULT_MODBUS_PORT_TEST));
@@ -145,7 +150,8 @@ TEST_F(PilzModbusReadClientTests, failingInitialization)
       .Times(1)
       .WillOnce(Return(false));
 
-  PilzModbusReadClient client(nh_,REGISTER_SIZE_TEST,REGISTER_FIRST_IDX_TEST,std::move(mock));
+  PilzModbusReadClient client(nh_, TOPIC_TEST, REGISTER_FIRST_IDX_TEST, REGISTER_SIZE_TEST,
+          DEFAULT_RATE_HZ_TEST, std::move(mock));;
 
   EXPECT_FALSE(client.init(LOCALHOST, DEFAULT_MODBUS_PORT_TEST));
 }
@@ -162,7 +168,8 @@ TEST_F(PilzModbusReadClientTests, failingInitializationWithRetry)
       .WillOnce(Return(false))
       .WillOnce(Return(false));
 
-  PilzModbusReadClient client(nh_,REGISTER_SIZE_TEST,REGISTER_FIRST_IDX_TEST,std::move(mock));
+  PilzModbusReadClient client(nh_, TOPIC_TEST, REGISTER_FIRST_IDX_TEST, REGISTER_SIZE_TEST,
+          DEFAULT_RATE_HZ_TEST, std::move(mock));;
 
   EXPECT_FALSE(client.init(LOCALHOST, DEFAULT_MODBUS_PORT_TEST, REGISTER_SIZE_TEST, ros::Duration(0.1)));
 }
@@ -200,7 +207,8 @@ TEST_F(PilzModbusReadClientTests, properReadingAndDisconnect)
         .WillOnce(ACTION_OPEN_BARRIER_VOID("disconnected"));
   }
 
-  PilzModbusReadClient client(nh_,REGISTER_SIZE_TEST,REGISTER_FIRST_IDX_TEST,std::move(mock));
+  PilzModbusReadClient client(nh_, TOPIC_TEST, REGISTER_FIRST_IDX_TEST, REGISTER_SIZE_TEST,
+          DEFAULT_RATE_HZ_TEST, std::move(mock));;
 
   EXPECT_TRUE(client.init(LOCALHOST, DEFAULT_MODBUS_PORT_TEST));
   EXPECT_NO_THROW(client.run());
@@ -218,7 +226,8 @@ TEST_F(PilzModbusReadClientTests, runningWithoutInit)
   EXPECT_CALL(*mock, readHoldingRegister(_,_)).Times(0);
   EXPECT_CALL(*this, modbus_read_cb(_)).Times(0);
 
-  PilzModbusReadClient client(nh_,REGISTER_SIZE_TEST,REGISTER_FIRST_IDX_TEST,std::move(mock));
+  PilzModbusReadClient client(nh_, TOPIC_TEST, REGISTER_FIRST_IDX_TEST, REGISTER_SIZE_TEST,
+                              DEFAULT_RATE_HZ_TEST, std::move(mock));
 
   EXPECT_THROW(client.run(), PilzModbusReadClientException);
 }
@@ -237,7 +246,8 @@ TEST_F(PilzModbusReadClientTests, terminateRunningClient)
   ON_CALL(*this, modbus_read_cb(IsSuccessfullRead(std::vector<uint16_t>{3,4})))
     .WillByDefault(Return());
 
-  auto client = std::make_shared< PilzModbusReadClient >(nh_,REGISTER_SIZE_TEST,REGISTER_FIRST_IDX_TEST,std::move(mock));
+  auto client = std::make_shared< PilzModbusReadClient >(nh_, TOPIC_TEST, REGISTER_FIRST_IDX_TEST, REGISTER_SIZE_TEST,
+          DEFAULT_RATE_HZ_TEST, std::move(mock));
 
   EXPECT_TRUE(client->init(LOCALHOST, DEFAULT_MODBUS_PORT_TEST));
 


### PR DESCRIPTION
The idea is to provide a Modbus client that can read multiple different registers from the same master. These registers can have individual topics and rates.

This is WIP. We have to discuss the details. Probably this can also be extended to write. And to read registers other than the holding register.