### PR TITLE
Remove #attempts from kinematics solver config

### DIFF
--- a/prbt_moveit_config/config/kinematics.yaml
+++ b/prbt_moveit_config/config/kinematics.yaml
@@ -1,5 +1,4 @@
 manipulator:
   kinematics_solver: prbt_manipulator/IKFastKinematicsPlugin
-  kinematics_solver_attempts: 3
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005


### PR DESCRIPTION
Fixes a warning that was still appearing after updating the ikfast plugin (2be9cc6f5913c4c89e61d99ba917d6bc0b726b04).
Fixes #83