### PR TITLE
do not install test headers

### DIFF
--- a/prbt_hardware_support/CMakeLists.txt
+++ b/prbt_hardware_support/CMakeLists.txt
@@ -79,7 +79,7 @@ target_link_libraries(pilz_modbus_read_client_node ${catkin_LIBRARIES} modbus)
 #############
 
 install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-install(DIRECTORY include/${PROJECT_NAME}/ test/include/${PROJECT_NAME}/
+install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
   FILES_MATCHING PATTERN "*.h"
   PATTERN ".svn" EXCLUDE)


### PR DESCRIPTION
1. The headers are not needed at runtime
2. Pollutes code_coverage report