### PR TITLE
Add setter for Modbus-Response-Timeout and Modbus-Read-Frequency

### DIFF
--- a/prbt_hardware_support/README.md
+++ b/prbt_hardware_support/README.md
@@ -43,6 +43,14 @@ A Modbus client (for usage with the PNOZmulti or PSS4000) can be started with `r
 - num_registers_to_read
 - modbus_connection_retries (default: 10)
 - modbus_connection_retry_timeout - timeout between retries (default: 1s)
+- modbus_response_timeout (default: 20ms)
+- modbus_topic_name (default: "/pilz_modbus_node/modbus_read")
+
+**Please note:**
+- The parameters ``modbus_response_timeout`` and ``modbus_topic_name`` are
+important for the Safe stop 1 functionality and must NOT be given, if the
+``modbus_read_node`` is used as part of the Safe stop 1 functionality.
+If the parameters are not given the default values for these parameters are used.
 
 ## StoModbusAdapterNode
 The ``PilzStoModbusAdapterNode`` is noticed via the topic `/pilz_modbus_node/modbus_read` if the STO is true or false and reacts as follows calling the corresponding services of the controllers and drivers:

--- a/prbt_hardware_support/include/prbt_hardware_support/param_names.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/param_names.h
@@ -25,6 +25,8 @@ namespace prbt_hardware_support
 
 static const std::string PARAM_MODBUS_SERVER_IP_STR {"modbus_server_ip"};
 static const std::string PARAM_MODBUS_SERVER_PORT_STR {"modbus_server_port"};
+static const std::string PARAM_MODBUS_RESPONSE_TIMEOUT_STR {"modbus_response_timeout"};
+static const std::string PARAM_MODBUS_TOPIC_NAME_STR {"modbus_topic_name"};
 static const std::string PARAM_INDEX_OF_FIRST_REGISTER_TO_READ_STR {"index_of_first_register_to_read"};
 static const std::string PARAM_NUM_REGISTERS_TO_READ_STR {"num_registers_to_read"};
 static const std::string PARAM_MODBUS_CONNECTION_RETRIES {"modbus_connection_retries"};

--- a/prbt_hardware_support/include/prbt_hardware_support/pilz_modbus_read_client.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/pilz_modbus_read_client.h
@@ -41,13 +41,17 @@ public:
    * @param num_registers_to_read Size of the data array.
    * @param index_of_first_register Offset of the modbus data.
    * @param ModbusClient to use
+   * @param response_timeout_ms Time to wait for a response from Modbus server.
+   * @param topic_name Name under which ROS-Modbus message is published.
+   * @param read_frequency_hz Defines how often Modbus registers are read in.
    */
   PilzModbusReadClient(ros::NodeHandle& nh,
                        const unsigned int num_registers_to_read,
                        const unsigned int index_of_first_register,
-                       ModbusClientUniquePtr modbus_client);
-
-  ~PilzModbusReadClient(){}
+                       ModbusClientUniquePtr modbus_client,
+                       unsigned int response_timeout_ms,
+                       const std::string& modbus_topic_name,
+                       double read_frequency_hz = DEFAULT_MODBUS_READ_FREQUENCY_HZ);
 
 public:
   /**
@@ -109,10 +113,13 @@ private:
   //! Index from which the registers have to be read.
   const uint32_t INDEX_OF_FIRST_REGISTER;
 
-  static constexpr unsigned int RESPONSE_TIMEOUT_IN_MS {20};
+  //! Defines how long we wait for a response from the Modbus-server.
+  const unsigned int RESPONSE_TIMEOUT_MS;
+  //! Defines how often the Modbus registers are read in.
+  const double READ_FREQUENCY_HZ;
 
-  static constexpr double MODBUS_RATE_HZ {500};
-
+private:
+  static constexpr double DEFAULT_MODBUS_READ_FREQUENCY_HZ {500};
   static constexpr int DEFAULT_QUEUE_SIZE_MODBUS {1};
 
 private:

--- a/prbt_hardware_support/src/pilz_modbus_read_client_node.cpp
+++ b/prbt_hardware_support/src/pilz_modbus_read_client_node.cpp
@@ -17,6 +17,8 @@
 
 #include <stdlib.h>
 #include <string>
+#include <stdexcept>
+#include <sstream>
 
 #include <ros/ros.h>
 
@@ -24,9 +26,42 @@
 #include <prbt_hardware_support/pilz_modbus_read_client.h>
 #include <prbt_hardware_support/param_names.h>
 #include <prbt_hardware_support/pilz_modbus_read_client_exception.h>
+#include <prbt_hardware_support/modbus_topic_definitions.h>
 
 static constexpr int32_t MODBUS_CONNECTION_RETRIES_DEFAULT {10};
 static constexpr double MODBUS_CONNECTION_RETRY_TIMEOUT_S_DEFAULT {1.0};
+static constexpr int MODBUS_RESPONSE_TIMEOUT_MS {20};
+
+namespace prbt_hardware_support
+{
+/**
+   * @brief Exception used by the getParam function.
+   */
+class GetParamException : public std::runtime_error
+{
+public:
+  GetParamException(const std::string& msg);
+};
+
+inline GetParamException::GetParamException(const std::string& msg)
+  : std::runtime_error (msg)
+{
+
+}
+
+template<class T>
+T getParam(const ros::NodeHandle& nh, const std::string& param_name)
+{
+  T ret_val;
+  if ( !nh.getParam(param_name, ret_val) )
+  {
+    std::ostringstream os;
+    os << "Parameter \"" << param_name << "\" not given";
+    throw GetParamException(os.str());
+  }
+  return ret_val;
+}
+}
 
 using namespace prbt_hardware_support;
 
@@ -40,31 +75,17 @@ int main(int argc, char **argv)
   ros::NodeHandle nh {"~"};
 
   // LCOV_EXCL_START Simple parameter reading not analyzed
-  std::string ip {};
-  if ( !nh.getParam(PARAM_MODBUS_SERVER_IP_STR, ip) )
+  std::string ip;
+  int port, num_registers_to_read, index_of_first_register;
+  try
   {
-    ROS_ERROR("No modbus server ip given. Abort.");
-    return EXIT_FAILURE;
-  }
-
-  int port {0};
-  if ( !nh.getParam(PARAM_MODBUS_SERVER_PORT_STR, port) )
+    ip = getParam<std::string>(nh, PARAM_MODBUS_SERVER_IP_STR);
+    port = getParam<int>(nh, PARAM_MODBUS_SERVER_PORT_STR);
+    num_registers_to_read = getParam<int>(nh, PARAM_NUM_REGISTERS_TO_READ_STR);
+    index_of_first_register = getParam<int>(nh, PARAM_INDEX_OF_FIRST_REGISTER_TO_READ_STR);
+  } catch (const GetParamException& ex)
   {
-    ROS_ERROR("No modbus server port given. Abort.");
-    return EXIT_FAILURE;
-  }
-
-  int num_registers_to_read {0};
-  if ( !nh.getParam(PARAM_NUM_REGISTERS_TO_READ_STR, num_registers_to_read) )
-  {
-    ROS_ERROR("Numbers of registers to read not given. Abort.");
-    return EXIT_FAILURE;
-  }
-
-  int index_of_first_register {0};
-  if ( !nh.getParam(PARAM_INDEX_OF_FIRST_REGISTER_TO_READ_STR, index_of_first_register) )
-  {
-    ROS_ERROR("Index of first register not given. Abort.");
+    ROS_ERROR_STREAM(ex.what());
     return EXIT_FAILURE;
   }
 
@@ -73,22 +94,35 @@ int main(int argc, char **argv)
 
   double modbus_connection_retry_timeout_s {MODBUS_CONNECTION_RETRY_TIMEOUT_S_DEFAULT};
   nh.param<double>(PARAM_MODBUS_CONNECTION_RETRY_TIMEOUT, modbus_connection_retry_timeout_s,
-           MODBUS_CONNECTION_RETRY_TIMEOUT_S_DEFAULT);
+                   MODBUS_CONNECTION_RETRY_TIMEOUT_S_DEFAULT);
+
+  int response_timeout_ms;
+  nh.param<int>(PARAM_MODBUS_RESPONSE_TIMEOUT_STR, response_timeout_ms,
+                MODBUS_RESPONSE_TIMEOUT_MS);
+
+  std::string modbus_topic_name;
+  nh.param<std::string>(PARAM_MODBUS_TOPIC_NAME_STR, modbus_topic_name,
+                        TOPIC_MODBUS_READ);
+
 
   // LCOV_EXCL_STOP
 
   prbt_hardware_support::PilzModbusReadClient modbus_client(nh,
-                                                  static_cast<uint32_t>(num_registers_to_read),
-                                                  static_cast<uint32_t>(index_of_first_register),
-                                                  std::unique_ptr<LibModbusClient>(new LibModbusClient()));
+                                                            static_cast<uint32_t>(num_registers_to_read),
+                                                            static_cast<uint32_t>(index_of_first_register),
+                                                            std::unique_ptr<LibModbusClient>(new LibModbusClient()),
+                                                            static_cast<unsigned int>(response_timeout_ms),
+                                                            modbus_topic_name);
 
   ROS_DEBUG_STREAM("Modbus client IP: " << ip << " | Port: " << port);
   ROS_DEBUG_STREAM("Number of registers to read: " << num_registers_to_read
                    << "| first register: " << index_of_first_register);
+  ROS_DEBUG_STREAM("Modbus response timeout: " << response_timeout_ms
+                   << "Modbus topic name: " << modbus_topic_name);
 
 
   bool res = modbus_client.init(ip.c_str(), static_cast<unsigned int>(port),
-                                            static_cast<unsigned int>(modbus_connection_retries),
+                                static_cast<unsigned int>(modbus_connection_retries),
                                 ros::Duration(modbus_connection_retry_timeout_s));
 
   ROS_DEBUG_STREAM("Connection with modbus server " << ip << ":" << port << " established");

--- a/prbt_hardware_support/test/unittests/unittest_pilz_modbus_read_client.cpp
+++ b/prbt_hardware_support/test/unittests/unittest_pilz_modbus_read_client.cpp
@@ -73,7 +73,10 @@ protected:
   ros::NodeHandle nh_;
 
   MOCK_METHOD1(modbus_read_cb,  void(ModbusMsgInStamped msg));
+
 };
+
+void callbackDummy(const ModbusMsgInStampedConstPtr& /*msg*/) {}
 
 void PilzModbusReadClientTests::SetUp()
 {
@@ -279,6 +282,23 @@ TEST_F(PilzModbusReadClientTests, terminateRunningClient)
   }
   EXPECT_FALSE(client->isRunning());
   running_thread.join();
+}
+
+/**
+ * @brief Test that topic name can be changed.
+ */
+TEST_F(PilzModbusReadClientTests, testTopicNameChange)
+{
+  std::unique_ptr<PilzModbusClientMock> mock(new PilzModbusClientMock());
+
+  const std::string topic_name {"test_topic_name"};
+
+  auto client = std::make_shared< PilzModbusReadClient >(nh_,REGISTER_SIZE_TEST,REGISTER_FIRST_IDX_TEST,std::move(mock),
+                                                         RESPONSE_TIMEOUT, topic_name);
+  // Wait for a moment to ensure the topic is "up and running"
+  ros::Duration(WAIT_SLEEPTIME_S).sleep();
+  ros::Subscriber sub = nh_.subscribe<ModbusMsgInStamped>(topic_name, 1, &callbackDummy);
+  ASSERT_EQ(1u, sub.getNumPublishers());
 }
 
 }  // namespace pilz_modbus_read_client_test

--- a/prbt_hardware_support/test/unittests/unittest_pilz_modbus_read_client.cpp
+++ b/prbt_hardware_support/test/unittests/unittest_pilz_modbus_read_client.cpp
@@ -285,7 +285,7 @@ TEST_F(PilzModbusReadClientTests, terminateRunningClient)
 }
 
 /**
- * @brief Test that topic name can be changed.
+ * @brief Tests that topic name can be changed.
  */
 TEST_F(PilzModbusReadClientTests, testTopicNameChange)
 {
@@ -299,6 +299,27 @@ TEST_F(PilzModbusReadClientTests, testTopicNameChange)
   ros::Duration(WAIT_SLEEPTIME_S).sleep();
   ros::Subscriber sub = nh_.subscribe<ModbusMsgInStamped>(topic_name, 1, &callbackDummy);
   ASSERT_EQ(1u, sub.getNumPublishers());
+}
+
+/**
+ * @brief Tests that response timeout can be changed.
+ */
+TEST_F(PilzModbusReadClientTests, testSettingOfTimeOut)
+{
+  std::unique_ptr<PilzModbusClientMock> mock(new PilzModbusClientMock());
+
+  const unsigned int response_timeout {RESPONSE_TIMEOUT + 4};
+
+  EXPECT_CALL(*mock, init(_,_))
+      .Times(1)
+      .WillOnce(Return(true));
+
+  EXPECT_CALL(*mock, setResponseTimeoutInMs(response_timeout)).Times(1);
+
+  auto client = std::make_shared< PilzModbusReadClient >(nh_,REGISTER_SIZE_TEST,REGISTER_FIRST_IDX_TEST,std::move(mock),
+                                                         response_timeout, prbt_hardware_support::TOPIC_MODBUS_READ);
+
+  EXPECT_TRUE(client->init(LOCALHOST, DEFAULT_MODBUS_PORT_TEST));
 }
 
 }  // namespace pilz_modbus_read_client_test

--- a/prbt_hardware_support/test/unittests/unittest_pilz_modbus_read_client.cpp
+++ b/prbt_hardware_support/test/unittests/unittest_pilz_modbus_read_client.cpp
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <vector>
 #include <string>
+#include <mutex>
 
 #include <ros/ros.h>
 #include <modbus/modbus.h>
@@ -45,6 +46,7 @@ using ::testing::Return;
 using ::testing::Throw;
 using ::testing::InSequence;
 using ::testing::InvokeWithoutArgs;
+using ::testing::Invoke;
 using namespace prbt_hardware_support;
 
 static constexpr unsigned int DEFAULT_MODBUS_PORT_TEST {502};
@@ -55,6 +57,58 @@ static constexpr unsigned int RESPONSE_TIMEOUT {10};
 static constexpr double WAIT_FOR_START_TIMEOUT_S {3.0};
 static constexpr double WAIT_SLEEPTIME_S {0.1};
 static constexpr double WAIT_FOR_STOP_TIMEOUT_S {3.0};
+
+/**
+ * @brief Helper class to simplify the threading of the PilzModbusReadClient.
+ */
+class PilzModbusReadClientExecutor
+{
+public:
+  PilzModbusReadClientExecutor(PilzModbusReadClient* client);
+
+public:
+  void start();
+  void stop();
+
+private:
+  PilzModbusReadClient* client_;
+  std::thread client_thread_;
+};
+
+PilzModbusReadClientExecutor::PilzModbusReadClientExecutor(PilzModbusReadClient* client)
+  : client_(client)
+{
+}
+
+void PilzModbusReadClientExecutor::start()
+{
+  client_thread_ = std::thread(&PilzModbusReadClient::run, client_);
+
+  ros::Time start_waiting = ros::Time::now();
+  while (!client_->isRunning())
+  {
+    ros::Duration(WAIT_SLEEPTIME_S).sleep();
+    if (ros::Time::now() > start_waiting + ros::Duration(WAIT_FOR_START_TIMEOUT_S))
+    {
+      break;
+    }
+  }
+}
+
+void PilzModbusReadClientExecutor::stop()
+{
+  client_->terminate();
+  ros::Time start_waiting = ros::Time::now();
+  while (client_->isRunning())
+  {
+    ros::Duration(WAIT_SLEEPTIME_S).sleep();
+    if (ros::Time::now() > start_waiting + ros::Duration(WAIT_FOR_STOP_TIMEOUT_S))
+    {
+      break;
+    }
+  }
+  client_thread_.join();
+}
 
 /**
  * @brief Test if PilzModbusReadClient correctly publishes ROS-Modbus messages.
@@ -75,8 +129,6 @@ protected:
   MOCK_METHOD1(modbus_read_cb,  void(ModbusMsgInStamped msg));
 
 };
-
-void callbackDummy(const ModbusMsgInStampedConstPtr& /*msg*/) {}
 
 void PilzModbusReadClientTests::SetUp()
 {
@@ -253,36 +305,14 @@ TEST_F(PilzModbusReadClientTests, terminateRunningClient)
 
   EXPECT_TRUE(client->init(LOCALHOST, DEFAULT_MODBUS_PORT_TEST));
 
-  auto running_thread = std::thread([client]
-  {
-    client->run();
-  });
-
-  ros::Time start_waiting = ros::Time::now();
-  while (!client->isRunning())
-  {
-    ros::Duration(WAIT_SLEEPTIME_S).sleep();
-    if (ros::Time::now() > start_waiting + ros::Duration(WAIT_FOR_START_TIMEOUT_S))
-    {
-      break;
-    }
-  }
+  PilzModbusReadClientExecutor executor(client.get());
+  executor.start();
   EXPECT_TRUE(client->isRunning());
-
-  client->terminate();
-
-  start_waiting = ros::Time::now();
-  while (client->isRunning())
-  {
-    ros::Duration(WAIT_SLEEPTIME_S).sleep();
-    if (ros::Time::now() > start_waiting + ros::Duration(WAIT_FOR_STOP_TIMEOUT_S))
-    {
-      break;
-    }
-  }
+  executor.stop();
   EXPECT_FALSE(client->isRunning());
-  running_thread.join();
 }
+
+void callbackDummy(const ModbusMsgInStampedConstPtr& /*msg*/) {}
 
 /**
  * @brief Tests that topic name can be changed.
@@ -320,6 +350,142 @@ TEST_F(PilzModbusReadClientTests, testSettingOfTimeOut)
                                                          response_timeout, prbt_hardware_support::TOPIC_MODBUS_READ);
 
   EXPECT_TRUE(client->init(LOCALHOST, DEFAULT_MODBUS_PORT_TEST));
+}
+
+/**
+ * @brief Strictly increases the holding register each time the
+ * "readHoldingRegister" method is called.
+ */
+class HoldingRegisterIncreaser
+{
+public:
+  HoldingRegisterIncreaser(unsigned int register_index = 0u)
+    : register_index_(register_index)
+  {}
+
+public:
+  std::vector<uint16_t> readHoldingRegister(int /*addr*/, int nb)
+  {
+    std::vector<uint16_t> vec( static_cast<std::vector<uint16_t>::size_type>(nb) , 0u);
+    vec.at(register_index_) = curr_count_;
+    ++curr_count_;
+    return vec;
+  }
+
+private:
+  const unsigned int register_index_;
+  uint16_t curr_count_ {0};
+};
+
+class RegisterBuffer
+{
+public:
+  void add(ModbusMsgInStamped msg)
+  {
+    std::unique_lock<std::mutex> lk(m_);
+    buffer_ = msg.holding_registers.data.at(0);
+  }
+
+  uint16_t get()
+  {
+    std::unique_lock<std::mutex> lk(m_);
+    return buffer_;
+  }
+
+private:
+  std::mutex m_;
+  uint16_t buffer_;
+};
+
+/**
+ * @brief Tests that the frequency with which the registers are read,
+ * can be changed.
+ *
+ * This test does NOT precisly check (tolerance ca. 10Hz) if the exact
+ * frequency could be set. It just checks that the frequency was
+ * changed.
+ *
+ *
+ * Test Sequence:
+ * - 1. Choose low read frequency (f1). The last received "modbus_read" messages
+ *      is stored in a buffer.
+ * - 2. Choose "modbus_read" topic check frequency f2, with f2 slightly bigger than f1.
+ * - 3. Start a loop (running exactly for #f1 iterations), which checks with
+ *      frequency f2 the last received "modbus_read" message.
+ * - 4. Stop all loops and the PilzModbusReadClient.
+ *
+ * Expected Results:
+ * - 1. -
+ * - 2. -
+ * - 3. The last received "modbus_read" messges must fullfill the condition:
+ *      "new_register_value = last_register_value + 1".
+ *      If the condition does not hold, the read fequency could not be
+ *      set properly and is probably to high.
+ * - 4. Check that the number of received messages is creater than #f1. If the
+ *      condition does not hold, the read fequency is not set properly
+ *      and is probably to low.
+ */
+TEST_F(PilzModbusReadClientTests, testSettingReadFrequency)
+{
+  std::unique_ptr<PilzModbusClientMock> mock(new PilzModbusClientMock());
+
+  EXPECT_CALL(*mock, init(_,_))
+      .Times(1)
+      .WillOnce(Return(true));
+
+  HoldingRegisterIncreaser fake_holding_register;
+  ON_CALL(*mock, readHoldingRegister(_, _))
+      .WillByDefault(Invoke(&fake_holding_register, &HoldingRegisterIncreaser::readHoldingRegister));
+
+  RegisterBuffer buffer;
+  ON_CALL(*this, modbus_read_cb(_))
+      .WillByDefault(Invoke(&buffer, &RegisterBuffer::add));
+
+  const double expected_read_frequency {30.0};
+  auto client = std::make_shared< PilzModbusReadClient >(nh_,REGISTER_SIZE_TEST,REGISTER_FIRST_IDX_TEST,std::move(mock),
+                                                         RESPONSE_TIMEOUT, prbt_hardware_support::TOPIC_MODBUS_READ,
+                                                         expected_read_frequency);
+
+  EXPECT_TRUE(client->init(LOCALHOST, DEFAULT_MODBUS_PORT_TEST));
+
+  PilzModbusReadClientExecutor executor(client.get());
+  executor.start();
+  EXPECT_TRUE(client->isRunning());
+
+  // The "modbus_read" messages from the PilzModbusReadClient are checked
+  // faster as the set read frequency, to ensure that
+  // all messages from the PilzModbusReadClient are processed by the test.
+  const double msg_check_frequency {1.2*expected_read_frequency};
+  // The timeout indirectly defines how many messages are checked
+  // for "correctness".
+  const unsigned int N_TIMEOUT { static_cast<unsigned int>(msg_check_frequency) + 1u };
+  uint16_t last {0};
+  bool first_value_set {false};
+  ros::Rate rate(msg_check_frequency);
+  for(unsigned int counter = 0; (counter < N_TIMEOUT) && ros::ok(); ++counter )
+  {
+    rate.sleep();
+    if (!first_value_set)
+    {
+      last = buffer.get();
+      first_value_set = true;
+      continue;
+    }
+
+    uint16_t curr_value = buffer.get();
+    if (curr_value == last)
+    {
+      continue;
+    }
+    uint16_t expected_value = last + 1u;
+    EXPECT_EQ(expected_value, curr_value) << "Frequency used by PilzModbusReadClient is probably too higher";
+    last = curr_value;
+  }
+
+  EXPECT_GE(buffer.get(), static_cast<uint16_t>(expected_read_frequency)) << "Frequency used by PilzModbusReadClient is probably too lower";
+
+  executor.stop();
+  EXPECT_FALSE(client->isRunning());
 }
 
 }  // namespace pilz_modbus_read_client_test


### PR DESCRIPTION
Allow a more flexible usage of the PilzModbusReadClient.