### PR TITLE
Add firmeware version logging at start-up

### DIFF
--- a/prbt_hardware_support/CMakeLists.txt
+++ b/prbt_hardware_support/CMakeLists.txt
@@ -99,6 +99,15 @@ add_executable(canopen_braketest_adapter_node
 add_dependencies(canopen_braketest_adapter_node ${catkin_EXPORTED_TARGETS} ${PROJECT_NAME}_generate_messages_cpp)
 target_link_libraries(canopen_braketest_adapter_node ${catkin_LIBRARIES})
 
+# SYSTEM_INFO_NODE
+add_executable(system_info_node
+  src/system_info_node.cpp
+  src/system_info.cpp
+  src/system_info_exception.cpp
+)
+add_dependencies(system_info_node ${catkin_EXPORTED_TARGETS} ${PROJECT_NAME}_generate_messages_cpp)
+target_link_libraries(system_info_node ${catkin_LIBRARIES})
+
 # +++++++++++++++++++++++++++++++++
 # + Build modbus read client node +
 # +++++++++++++++++++++++++++++++++
@@ -129,6 +138,7 @@ install(TARGETS
   modbus_adapter_brake_test_node
   brake_test_executor_node
   modbus_adapter_operation_mode_node
+  system_info_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
@@ -346,6 +356,19 @@ if(CATKIN_ENABLE_TESTING)
     ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
   )
   add_dependencies(integrationtest_trigger_brake_test ${catkin_EXPORTED_TARGETS})
+
+  #--- SystemInfo unit test ---
+  add_rostest_gmock(unittest_system_info
+      test/unittests/unittest_system_info.test
+      test/unittests/unittest_system_info.cpp
+      src/system_info.cpp
+      src/system_info_exception.cpp
+  )
+  target_link_libraries(unittest_system_info
+    ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
+  )
+  add_dependencies(unittest_system_info ${${PROJECT_NAME}_EXPORTED_TARGETS})
+  #----------------------------------------
 
   # to run: catkin_make -DENABLE_COVERAGE_TESTING=ON package_name_coverage (adding -j1 recommended)
   if(ENABLE_COVERAGE_TESTING)

--- a/prbt_hardware_support/include/prbt_hardware_support/system_info.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/system_info.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2019 Pilz GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef PRBT_HARDWARE_SUPPORT_SYSTEM_INFO_H
+#define PRBT_HARDWARE_SUPPORT_SYSTEM_INFO_H
+
+#include <ros/ros.h>
+
+#include <string>
+#include <vector>
+#include <map>
+
+#include <canopen_chain_node/GetObject.h>
+
+namespace prbt_hardware_support
+{
+
+//! key = joint_name
+//! value = firmware version of joint
+using FirmwareCont = std::map<std::string, std::string>;
+
+/**
+ * @brief Provides easy access to system information which are of importance
+ * when analyzing bugs.
+ */
+class SystemInfo
+{
+public:
+  SystemInfo(ros::NodeHandle& nh);
+
+  /**
+   * @returns a container comprised of the firmware version of each joint
+   * of the robot.
+   */
+  FirmwareCont getFirmwareVersions();
+
+  /**
+   * @returns the firmware version of the specified joint.
+   */
+  std::string getFirmwareVersionOfJoint(const std::string& joint_name);
+
+private:
+  /**
+   * @returns the names of all joints/nodes.
+   */
+  static std::vector<std::string> getNodeNames(const ros::NodeHandle &nh);
+
+private:
+  const std::vector<std::string> joint_names_;
+  ros::ServiceClient canopen_srv_get_client_;
+};
+
+} // namespace prbt_hardware_support
+#endif // PRBT_HARDWARE_SUPPORT_SYSTEM_INFO_H

--- a/prbt_hardware_support/include/prbt_hardware_support/system_info_exception.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/system_info_exception.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Pilz GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef PRBT_HARDWARE_SUPPORT_SYSTEM_INFO_EXCEPTION_H
+#define PRBT_HARDWARE_SUPPORT_SYSTEM_INFO_EXCEPTION_H
+
+#include <stdexcept>
+
+namespace prbt_hardware_support
+{
+
+/**
+ * @brief Exception thrown by the SystemInfo class in case of an error.
+ */
+class SystemInfoException : public std::runtime_error
+{
+public:
+  SystemInfoException(const std::string &what_arg);
+};
+
+
+}
+
+#endif // PRBT_HARDWARE_SUPPORT_SYSTEM_INFO_EXCEPTION_H

--- a/prbt_hardware_support/include/prbt_hardware_support/wait_for_service.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/wait_for_service.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019 Pilz GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef WAIT_FOR_SERVICE_H
+#define WAIT_FOR_SERVICE_H
+
+#include <string>
+
+#include <ros/ros.h>
+#include <ros/duration.h>
+
+#include <prbt_hardware_support/wait_for_timeouts.h>
+
+namespace prbt_hardware_support
+{
+
+/**
+ * @brief Waits until the specified service starts.
+ */
+static void waitForService(const std::string service_name,
+                    const double retry_timeout = DEFAULT_RETRY_TIMEOUT,
+                    const double msg_output_period = DEFAULT_MSG_OUTPUT_PERIOD)
+{
+  while (!ros::service::waitForService(service_name, ros::Duration(retry_timeout)) && ros::ok())
+  {
+    ROS_WARN_STREAM_DELAYED_THROTTLE(msg_output_period,
+                                     "Waiting for service \""
+                                     + service_name + "\"...");
+  }
+}
+
+
+}
+
+#endif // WAIT_FOR_SERVICE_H

--- a/prbt_hardware_support/include/prbt_hardware_support/wait_for_timeouts.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/wait_for_timeouts.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 Pilz GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef WAIT_FOR_TIMEOUTS_H
+#define WAIT_FOR_TIMEOUTS_H
+
+namespace prbt_hardware_support
+{
+
+static constexpr double DEFAULT_RETRY_TIMEOUT {0.2};
+static constexpr double DEFAULT_MSG_OUTPUT_PERIOD {5.0};
+
+}
+
+#endif // WAIT_FOR_TIMEOUTS_H

--- a/prbt_hardware_support/include/prbt_hardware_support/wait_for_topic.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/wait_for_topic.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019 Pilz GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef WAIT_FOR_TOPIC_H
+#define WAIT_FOR_TOPIC_H
+
+#include <string>
+
+#include <ros/ros.h>
+#include <ros/duration.h>
+
+#include <prbt_hardware_support/wait_for_timeouts.h>
+
+namespace prbt_hardware_support
+{
+
+/**
+ * @brief Waits until the specified topic is received.
+ */
+template<class T>
+static void waitForTopic(const std::string topic_name,
+                  const double retry_timeout = DEFAULT_RETRY_TIMEOUT,
+                  const double msg_output_period = DEFAULT_MSG_OUTPUT_PERIOD)
+{
+  while ( (ros::topic::waitForMessage<T>(topic_name, ros::Duration(retry_timeout)) == nullptr) && ros::ok())
+  {
+    ROS_WARN_STREAM_DELAYED_THROTTLE(msg_output_period,
+                                     "Waiting for topic \""
+                                     + topic_name + "\"...");
+  }
+}
+
+}
+
+#endif // WAIT_FOR_TOPIC_H

--- a/prbt_hardware_support/src/system_info.cpp
+++ b/prbt_hardware_support/src/system_info.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2019 Pilz GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <prbt_hardware_support/system_info.h>
+
+#include <XmlRpcValue.h>
+#include <XmlRpcException.h>
+#include <sensor_msgs/JointState.h>
+
+#include <prbt_hardware_support/wait_for_service.h>
+#include <prbt_hardware_support/wait_for_topic.h>
+#include <canopen_chain_node/GetObject.h>
+#include <prbt_hardware_support/system_info_exception.h>
+
+namespace prbt_hardware_support
+{
+
+static const std::string CANOPEN_GETOBJECT_SERVICE_NAME{"/prbt/driver/get_object"};
+static const std::string CANOPEN_NODES_PARAMETER_NAME{"/prbt/driver/nodes"};
+static const std::string JOINT_STATE_TOPIC {"/joint_states"};
+
+static const std::string GET_FIRMWARE_VERION_OBJECT{"100A"};
+
+SystemInfo::SystemInfo(ros::NodeHandle &nh)
+    : joint_names_( getNodeNames(nh) )
+{
+  // Wait till CAN is up and running.
+  // Reason: If the first CAN service call happens before
+  // the CAN is fully initialized, the CAN will not start properly.
+  waitForTopic<sensor_msgs::JointState>(JOINT_STATE_TOPIC);
+
+  waitForService(CANOPEN_GETOBJECT_SERVICE_NAME);
+  canopen_srv_get_client_ = nh.serviceClient<canopen_chain_node::GetObject>(CANOPEN_GETOBJECT_SERVICE_NAME);
+}
+
+std::string SystemInfo::getFirmwareVersionOfJoint(const std::string& joint_name)
+{
+  canopen_chain_node::GetObject srv;
+  srv.request.node = joint_name;
+  srv.request.object = GET_FIRMWARE_VERION_OBJECT;
+  srv.request.cached = false;
+
+  ROS_INFO_STREAM("Call \"get firmware\" service for \"" << joint_name << "\"");
+  if (!canopen_srv_get_client_.call(srv))
+  {
+    throw SystemInfoException("CANopen service to request firmware version failed");
+  }
+
+  if (!srv.response.success)
+  {
+    throw SystemInfoException(srv.response.message);
+  }
+  return srv.response.value;
+}
+
+FirmwareCont SystemInfo::getFirmwareVersions()
+{
+  FirmwareCont versions;
+  for(const auto& joint : joint_names_)
+  {
+    versions[joint] = getFirmwareVersionOfJoint(joint);
+  }
+  return versions;
+}
+
+std::vector<std::string> SystemInfo::getNodeNames(const ros::NodeHandle& nh)
+{
+  XmlRpc::XmlRpcValue rpc;
+  if (!nh.getParam(CANOPEN_NODES_PARAMETER_NAME, rpc))
+  {
+    throw SystemInfoException("Could not read node names");
+  }
+
+  std::vector<std::string> node_names;
+  for (auto rpci = rpc.begin(); rpci != rpc.end(); ++rpci)
+  {
+    auto node_name = rpci->first.c_str();
+    node_names.push_back(node_name);
+  }
+  return node_names;
+}
+
+} // namespace prbt_hardware_support

--- a/prbt_hardware_support/src/system_info_exception.cpp
+++ b/prbt_hardware_support/src/system_info_exception.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019 Pilz GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <prbt_hardware_support/system_info_exception.h>
+
+namespace prbt_hardware_support
+{
+
+SystemInfoException::SystemInfoException(const std::string &what_arg)
+  : std::runtime_error(what_arg)
+{
+}
+
+} // prbt_hardware_support

--- a/prbt_hardware_support/src/system_info_node.cpp
+++ b/prbt_hardware_support/src/system_info_node.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019 Pilz GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <ros/ros.h>
+#include <prbt_hardware_support/system_info.h>
+
+using namespace prbt_hardware_support;
+
+/**
+ * @brief Logs important system information.
+ */
+// LCOV_EXCL_START
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "system_info");
+  ros::NodeHandle nh{"~"};
+
+  prbt_hardware_support::SystemInfo system_info(nh);
+  FirmwareCont versions {system_info.getFirmwareVersions()};
+  for (const auto& currElem : versions)
+  {
+    ROS_INFO("Firmware version [%s]: %s",
+             currElem.first.c_str(),
+             currElem.second.c_str());
+  }
+  return EXIT_SUCCESS;
+}
+// LCOV_EXCL_STOP

--- a/prbt_hardware_support/test/unittests/unittest_system_info.cpp
+++ b/prbt_hardware_support/test/unittests/unittest_system_info.cpp
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) 2019 Pilz GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <string>
+#include <vector>
+#include <thread>
+#include <atomic>
+#include <memory>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <ros/ros.h>
+#include <canopen_chain_node/GetObject.h>
+#include <sensor_msgs/JointState.h>
+
+#include <pilz_testutils/async_test.h>
+#include <prbt_hardware_support/system_info.h>
+#include <prbt_hardware_support/system_info_exception.h>
+#include <prbt_hardware_support/wait_for_topic.h>
+#include <prbt_hardware_support/wait_for_service.h>
+
+namespace system_info_tests
+{
+
+using canopen_chain_node::GetObject;
+using namespace prbt_hardware_support;
+using namespace testing;
+
+static const std::string GET_OBJECT_TOPIC_NAME{"get_object"};
+static const std::string JOINT_STATES_TOPIC_NAME{"joint_states"};
+static constexpr unsigned int JOINT_STATES_TOPIC_QUEUE_SIZE{1};
+
+/**
+ * @brief Collection of tests checking the functionality of the SystemInfo
+ * class.
+ *
+ */
+class SystemInfoTests : public testing::Test, public testing::AsyncTest
+{
+public:
+  virtual void SetUp() override;
+  virtual void TearDown() override;
+
+  void publishJointState();
+
+protected:
+  MOCK_METHOD2(executeGetObject,  bool(GetObject::Request&, GetObject::Response&));
+
+  void advertiseGetObjectService();
+
+protected:
+  // Needed so that service callback are proecessed. Otherwise test in which
+  // service are calls will hang.
+  ros::AsyncSpinner spinner_ {2};
+
+  const std::vector<std::string> joint_names_ {"joint1", "joint2"};
+  ros::ServiceServer get_obj_service_;
+  std::thread publisher_thread_;
+  std::atomic_bool terminate_ {false};
+
+};
+
+void SystemInfoTests::advertiseGetObjectService()
+{
+  ros::NodeHandle driver_nh {"/prbt/driver/"};
+  get_obj_service_ = driver_nh.advertiseService(GET_OBJECT_TOPIC_NAME,
+                                                &SystemInfoTests::executeGetObject,
+                                                this);
+}
+
+void SystemInfoTests::SetUp()
+{
+  spinner_.start();
+
+  // Set joint names on parameter server
+  ros::NodeHandle driver_nh {"/prbt/driver/"};
+  for(unsigned int i = 0; i < joint_names_.size(); ++i)
+  {
+    driver_nh.setParam("nodes/" + joint_names_.at(i) + "/id", static_cast<int>(i));
+  }
+
+  publisher_thread_ = std::thread(&SystemInfoTests::publishJointState, this);
+  advertiseGetObjectService();
+}
+
+void SystemInfoTests::TearDown()
+{
+  if (publisher_thread_.joinable())
+  {
+    terminate_ = true;
+    publisher_thread_.join();
+  }
+}
+
+void SystemInfoTests::publishJointState()
+{
+  ros::NodeHandle global_nh {"/"};
+  ros::Publisher joint_state_pub = global_nh.advertise<sensor_msgs::JointState>(
+        JOINT_STATES_TOPIC_NAME,
+        JOINT_STATES_TOPIC_QUEUE_SIZE);
+
+  while(!terminate_ && ros::ok())
+  {
+    joint_state_pub.publish(sensor_msgs::JointState());
+    ros::Duration(0.5).sleep();
+  }
+}
+
+/**
+ * @brief Tests that exception stores and returns correct error message.
+ */
+TEST_F(SystemInfoTests, TestExceptions)
+{
+  const std::string exp_msg {"Test-Msg"};
+  std::shared_ptr<SystemInfoException> ex {new SystemInfoException(exp_msg)};
+  EXPECT_TRUE(std::string(ex->what()) == exp_msg);
+}
+
+/**
+ * @brief Checks that exception is thrown if param "/prbt/driver/nodes" can
+ * not be found on parameter server.
+ */
+TEST_F(SystemInfoTests, testNodeNamesMissing)
+{
+  ros::NodeHandle nh{"~"};
+  nh.deleteParam("/prbt/driver/nodes");
+  EXPECT_THROW(SystemInfo{nh}, SystemInfoException);
+}
+
+/**
+ * @brief Tests that constructor waits until CAN is up and running by
+ * waiting for the "/joint_states" topic.
+ */
+TEST_F(SystemInfoTests, testCANUpAndRunning)
+{
+  // Make sure that no JointStates are published
+  terminate_ = true;
+  publisher_thread_.join();
+
+  // Variable stating if the constructor is finished or not.
+  std::atomic_bool ctor_called {false};
+  // Start thread which allows us to asynchronously call the constructor
+  std::thread async_ctor_call_thread = std::thread([this, &ctor_called] () {
+    ros::NodeHandle nh{"~"};
+    SystemInfo info(nh);
+    ctor_called = true;
+    this->triggerClearEvent("ctor_called");
+  });
+
+  // Wait a while and then check if constructor is still waiting for the topic.
+  ros::Duration(5.0 * DEFAULT_RETRY_TIMEOUT).sleep();
+  ASSERT_FALSE(ctor_called) << "Ctor already finished although \"/joint_states\" topic not published yet";
+
+  // Activate publishing of "/joint_states"
+  terminate_ = false;
+  publisher_thread_ = std::thread(&SystemInfoTests::publishJointState, this);
+  waitForTopic<sensor_msgs::JointState>("/joint_states");
+  // Wait till constructor is finished
+  BARRIER("ctor_called");
+
+  if (async_ctor_call_thread.joinable())
+  {
+    async_ctor_call_thread.join();
+  }
+}
+
+/**
+ * @brief Tests that constructor waits until ros_canopen service "get_object"
+ * is advertised.
+ */
+TEST_F(SystemInfoTests, testCANServiceUpAndRunning)
+{
+  // Make sure that no ros_canopen service "get_object" is advertised.
+  get_obj_service_.shutdown();
+
+  // Variable stating if the constructor is finished or not.
+  std::atomic_bool ctor_called {false};
+  // Start thread which allows us to asynchronously call the constructor
+  std::thread async_ctor_call_thread = std::thread([this, &ctor_called] () {
+    ros::NodeHandle nh{"~"};
+    SystemInfo info(nh);
+    ctor_called = true;
+    this->triggerClearEvent("ctor_called");
+  });
+
+  // Wait a while and then check if constructor is still waiting for the topic.
+  ros::Duration(5.0 * DEFAULT_RETRY_TIMEOUT).sleep();
+  ASSERT_FALSE(ctor_called) << "Ctor already finished although \"get_object\" service not advertised yet";
+
+  advertiseGetObjectService();
+  waitForService("/prbt/driver/get_object");
+  // Wait till constructor is finished
+  BARRIER("ctor_called");
+
+  if (async_ctor_call_thread.joinable())
+  {
+    async_ctor_call_thread.join();
+  }
+}
+
+/**
+ * @brief Tests that exception is thrown in case the service returns
+ * as response "false".
+ */
+TEST_F(SystemInfoTests, testServiceResponseFalse)
+{
+  EXPECT_CALL(*this, executeGetObject(_,_))
+      .Times(1)
+      .WillRepeatedly(testing::Invoke(
+                        [](GetObject::Request&, GetObject::Response& res){
+                        res.success = false;
+                        return true;
+                      }
+                      ));
+
+  ros::NodeHandle nh{"~"};
+  SystemInfo info {nh};
+  EXPECT_THROW(info.getFirmwareVersions(), SystemInfoException);
+}
+
+/**
+ * @brief Tests that exception is thrown in case the service returns "false".
+ */
+TEST_F(SystemInfoTests, testServiceFail)
+{
+  EXPECT_CALL(*this, executeGetObject(_,_))
+      .Times(1)
+      .WillRepeatedly(testing::Invoke(
+                        [](GetObject::Request&, GetObject::Response&){
+                        return false;
+                      }
+                      ));
+
+  ros::NodeHandle nh{"~"};
+  SystemInfo info {nh};
+  EXPECT_THROW(info.getFirmwareVersions(), SystemInfoException);
+}
+
+/**
+ * @brief Tests that SystemInfo class returns correct firmware versions for
+ * each joint, given that everything needed by SystemInfo class works correctly.
+ */
+TEST_F(SystemInfoTests, testGetFirmwareVersions)
+{
+  ASSERT_EQ(2u, joint_names_.size()) << "Number of joints in test set-up have changed => Change expected version container in test accordingly.";
+  const FirmwareCont exp_versions { {joint_names_.at(0), "101"},
+                                    {joint_names_.at(1), "777"}};
+
+  EXPECT_CALL(*this, executeGetObject(_,_))
+      .Times(2)
+      .WillRepeatedly(testing::Invoke(
+                        [exp_versions](GetObject::Request& req, GetObject::Response& res){
+                        res.value = exp_versions.at(req.node);
+                        res.success = true;
+                        return true;
+                      }
+                      ));
+
+  // Check that returned versions from service are correct
+  ros::NodeHandle nh{"~"};
+  SystemInfo info {nh};
+  FirmwareCont actual_version_cont {info.getFirmwareVersions()};
+  for(const auto& joint : joint_names_)
+  {
+    EXPECT_TRUE(actual_version_cont.find(joint) != actual_version_cont.cend()) << "No version for joint found";
+    EXPECT_EQ(exp_versions.at(joint), actual_version_cont.at(joint)) << "Expected and actual firmware version do not match";
+  }
+}
+
+
+}  // namespace system_info_tests
+
+
+int main(int argc, char *argv[])
+{
+  ros::init(argc, argv, "system_info_test");
+  ros::NodeHandle nh;
+
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/prbt_hardware_support/test/unittests/unittest_system_info.test
+++ b/prbt_hardware_support/test/unittests/unittest_system_info.test
@@ -1,0 +1,24 @@
+<!--
+Copyright (c) 2019 Pilz GmbH & Co. KG
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<launch>
+
+<test test-name="unittest_system_info"
+    pkg="prbt_hardware_support" type="unittest_system_info">
+</test>
+
+</launch>

--- a/prbt_support/launch/robot.launch
+++ b/prbt_support/launch/robot.launch
@@ -78,6 +78,9 @@
     <node pkg="rosservice" type="rosservice" name="robot_init" args="call --wait /prbt/driver/init"/>
   </group>
 
+  <node ns="prbt" pkg="prbt_hardware_support" name="system_info_node"
+        type="system_info_node" output="screen" />
+
 </launch>
 
 


### PR DESCRIPTION
To have a more complete picture of the system, in case a bug occurs,
the firmeware version of each joint is displayed at start-up on the
console.