### PR TITLE
Buildfarm failed after merge of braketest

### DIFF
--- a/prbt_hardware_support/CMakeLists.txt
+++ b/prbt_hardware_support/CMakeLists.txt
@@ -8,6 +8,7 @@ add_definitions(-Werror)
 add_definitions(-std=c++11)
 
 find_package(catkin REQUIRED COMPONENTS
+  canopen_chain_node
   message_filters
   message_generation
   roscpp

--- a/prbt_hardware_support/package.xml
+++ b/prbt_hardware_support/package.xml
@@ -16,6 +16,7 @@
   <url type="repository">https://github.com/PilzDE/pilz_robots</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>canopen_chain_node</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>libmodbus-dev</build_depend>
   <build_depend>message_generation</build_depend>


### PR DESCRIPTION
After merging the brake test branch, the buildfarm failed with the following output:

```
[ 92%] Building CXX object CMakeFiles/canopen_braketest_adapter_node.dir/src/canopen_braketest_adapter_node.cpp.o
In file included from /tmp/ws/src/pilz_robots/prbt_hardware_support/src/canopen_braketest_adapter_node.cpp:19:0:
/tmp/ws/src/pilz_robots/prbt_hardware_support/include/prbt_hardware_support/canopen_braketest_adapter.h:26:42: fatal error: canopen_chain_node/GetObject.h: No such file or directory
compilation terminated.
CMakeFiles/canopen_braketest_adapter_node.dir/build.make:62: recipe for target 'CMakeFiles/canopen_braketest_adapter_node.dir/src/canopen_braketest_adapter_node.cpp.o' failed
make[2]: *** [CMakeFiles/canopen_braketest_adapter_node.dir/src/canopen_braketest_adapter_node.cpp.o] Error 1
CMakeFiles/Makefile2:1335: recipe for target 'CMakeFiles/canopen_braketest_adapter_node.dir/all' failed
make[1]: *** [CMakeFiles/canopen_braketest_adapter_node.dir/all] Error 2
Makefile:138: recipe for target 'all' failed
make: *** [all] Error 2
<== Failed to process package 'prbt_hardware_support': 
  Command '['/tmp/ws/install_isolated/env.sh', 'make']' returned non-zero exit status 2

```

This was solved by adding `canopen_chain_node` as dependency of `prbt_hardware_support`