### PR TITLE
Add missing depend on canopen_chain_node

### DIFF
--- a/prbt_hardware_support/CHANGELOG.rst
+++ b/prbt_hardware_support/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package prbt_hardware_support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Add missing depend (CATKIN_DEPENDS and <run_depend>) on canopen_chain_node
+
 0.5.4 (2019-05-27)
 ------------------
 * increased modbus response timeout to 20ms

--- a/prbt_hardware_support/CMakeLists.txt
+++ b/prbt_hardware_support/CMakeLists.txt
@@ -41,7 +41,7 @@ generate_messages(
 ###################################
 catkin_package(
   INCLUDE_DIRS include
-  CATKIN_DEPENDS message_runtime std_msgs std_srvs sensor_msgs
+  CATKIN_DEPENDS message_runtime std_msgs std_srvs sensor_msgs canopen_chain_node
 )
 
 ###########

--- a/prbt_hardware_support/package.xml
+++ b/prbt_hardware_support/package.xml
@@ -29,6 +29,7 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>std_srvs</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>canopen_chain_node</run_depend>
 
   <!-- Test dependencies -->
   <test_depend>rostest</test_depend>


### PR DESCRIPTION
Fix for missing #include <canopen_chain_node/GetObject.h>