### PR TITLE
Revert "Increase modbus response timeout to 50ms"

### DIFF
--- a/prbt_hardware_support/CHANGELOG.rst
+++ b/prbt_hardware_support/CHANGELOG.rst
@@ -5,7 +5,6 @@ Changelog for package prbt_hardware_support
 Forthcoming
 -----------
 * enter hold mode at braketest execution
-* Increase modbus response timeout to avoid issues with pss
 * Contributors: Pilz GmbH and Co. KG
 
 0.5.6 (2019-06-12)

--- a/prbt_hardware_support/src/pilz_modbus_read_client_node.cpp
+++ b/prbt_hardware_support/src/pilz_modbus_read_client_node.cpp
@@ -28,7 +28,7 @@
 
 static constexpr int32_t MODBUS_CONNECTION_RETRIES_DEFAULT {10};
 static constexpr double MODBUS_CONNECTION_RETRY_TIMEOUT_S_DEFAULT {1.0};
-static constexpr int MODBUS_RESPONSE_TIMEOUT_MS {50};
+static constexpr int MODBUS_RESPONSE_TIMEOUT_MS {20};
 
 using namespace prbt_hardware_support;
 


### PR DESCRIPTION
Increasing the timeout has effects on the stopping distance and has to be configured with a matching time in the safety project. Please first discuss this and add more documentation!

Reverts PilzDE/pilz_robots#155