### PR TITLE
Fix dependencies of prbt_support

### DIFF
--- a/prbt_support/CMakeLists.txt
+++ b/prbt_support/CMakeLists.txt
@@ -26,7 +26,7 @@ if(CATKIN_ENABLE_TESTING)
 
   find_package(rostest REQUIRED)
   find_package(moveit_core REQUIRED)
-  find_package(moveit_kinematics REQUIRED)
+  find_package(moveit_ros_planning REQUIRED)
   find_package(cmake_modules REQUIRED)
   find_package(Eigen3 REQUIRED)
 

--- a/prbt_support/package.xml
+++ b/prbt_support/package.xml
@@ -32,7 +32,7 @@
 
   <test_depend>rostest</test_depend>
   <test_depend>moveit_core</test_depend>
-  <test_depend>moveit_kinematics</test_depend>
+  <test_depend>moveit_ros_planning</test_depend>
   <test_depend>cmake_modules</test_depend>
   <test_depend>eigen</test_depend>
   <test_depend>roslaunch</test_depend>


### PR DESCRIPTION
Replace test_depend moveit_kinematics by moveit_ros_planning.
Issue was revealed by https://github.com/ros-planning/moveit/pull/1529

See:
https://travis-ci.org/PilzDE/pilz_robots/builds/553642611