### PR TITLE
Fix broken loading of api_spec

### DIFF
--- a/prbt_hardware_support/launch/modbus_client.launch
+++ b/prbt_hardware_support/launch/modbus_client.launch
@@ -29,7 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <arg name="has_register_range_parameters"
        value="$(eval arg('index_of_first_register_to_read')!='' and arg('num_registers_to_read')!='')" />
 
-  <node required="true" pkg="prbt_hardware_support" type="pilz_modbus_client_node" name="pilz_modbus_client_node" output="screen">
+  <node ns="prbt" required="true" pkg="prbt_hardware_support" type="pilz_modbus_client_node" name="pilz_modbus_client_node" output="screen">
     <param name="modbus_server_ip" value="$(arg modbus_server_ip)"/>
     <param name="modbus_server_port" value="$(arg modbus_server_port)"/>
     <param if="$(arg has_register_range_parameters)" name="index_of_first_register_to_read" value="$(arg index_of_first_register_to_read)"/>


### PR DESCRIPTION
* The pilz_modbus_read_client look under /api_spec while it is loaded
  under /prbt/api_spec