### PR TITLE
Extend logging of unittest_libmodbus_client

### DIFF
--- a/prbt_hardware_support/src/libmodbus_client.cpp
+++ b/prbt_hardware_support/src/libmodbus_client.cpp
@@ -39,7 +39,7 @@ bool LibModbusClient::init(const char* ip, unsigned int port)
 
   if (modbus_connect(modbus_connection_) == -1)
   {
-    ROS_ERROR_STREAM("Could not establish modbus connection." << modbus_strerror(errno));
+    ROS_ERROR_STREAM_NAMED("LibModbusClient", "Could not establish modbus connection." << modbus_strerror(errno));
     modbus_free(modbus_connection_);
     modbus_connection_ = nullptr;
     return false;
@@ -77,7 +77,7 @@ RegCont LibModbusClient::readHoldingRegister(int addr, int nb)
   {
     std::string err = "Failed to read modbus registers! ";
     err.append(modbus_strerror(errno));
-    ROS_ERROR_STREAM(err);
+    ROS_ERROR_STREAM_NAMED("LibModbusClient", err);
     throw ModbusExceptionDisconnect(err);
   }
 
@@ -108,11 +108,14 @@ RegCont LibModbusClient::writeReadHoldingRegister(const int write_addr,
   rc = modbus_write_and_read_registers(modbus_connection_,
                                        write_addr, static_cast<int>(write_reg.size()), write_reg.data(),
                                        read_addr, read_nb, read_reg.data());
+  ROS_DEBUG_NAMED("LibModbusClient", "modbus_write_and_read_registers: writing from %i %i registers\
+                                      and reading from %i %i registers",
+                                      write_addr, static_cast<int>(write_reg.size()), read_addr, read_nb);
   if (rc == -1)
   {
     std::string err = "Failed to write and read modbus registers";
     err.append(modbus_strerror(errno));
-    ROS_ERROR_STREAM(err);
+    ROS_ERROR_STREAM_NAMED("LibModbusClient", err);
     throw ModbusExceptionDisconnect(err);
   }
 

--- a/prbt_hardware_support/test/include/prbt_hardware_support/pilz_modbus_server_mock.h
+++ b/prbt_hardware_support/test/include/prbt_hardware_support/pilz_modbus_server_mock.h
@@ -141,11 +141,14 @@ private:
 
 inline void PilzModbusServerMock::terminate()
 {
+  ROS_INFO_NAMED("ServerMock", "Terminate called on ServerMock.");
   terminate_ = true;
 
   if(thread_.joinable())
   {
+    ROS_DEBUG_NAMED("ServerMock", "Waiting for worker Thread of ServerMock to be joined.");
     thread_.join();
+    ROS_DEBUG_NAMED("ServerMock", "Waiting for worker Thread of ServerMock joined.");
   }
 }
 

--- a/prbt_hardware_support/test/unittests/pilz_modbus_server_mock.cpp
+++ b/prbt_hardware_support/test/unittests/pilz_modbus_server_mock.cpp
@@ -36,7 +36,7 @@ PilzModbusServerMock::PilzModbusServerMock(const unsigned int& holding_register_
   mb_mapping_ = modbus_mapping_new(BITS_NB, INPUT_BITS_NB, holding_register_size_, INPUT_REGISTERS_NB);
   if (mb_mapping_ == NULL)
   {
-    ROS_ERROR("mb_mapping_ is NULL.");
+    ROS_ERROR_NAMED("ServerMock", "mb_mapping_ is NULL.");
     throw std::runtime_error("mb_mapping_ is NULL.");
   }
 }
@@ -45,7 +45,7 @@ PilzModbusServerMock::~PilzModbusServerMock()
 {
   if (modbus_connection_)
   {
-    ROS_INFO("Close connection");
+    ROS_INFO_NAMED("ServerMock", "ModbusServer Mock is closing connection");
     modbus_close(modbus_connection_);
     modbus_free(modbus_connection_);
   }
@@ -62,7 +62,7 @@ bool PilzModbusServerMock::init(const char *ip, unsigned int port)
   }
   modbus_set_debug(modbus_connection_, true);
 
-  ROS_DEBUG_STREAM("Starting Listening on Port " << ip << ":" << port);
+  ROS_DEBUG_STREAM_NAMED("ServerMock", "Starting Listening on Port " << ip << ":" << port);
   return true;
 }
 
@@ -72,7 +72,7 @@ void PilzModbusServerMock::setHoldingRegister(std::initializer_list< std::pair<u
   {
     if (entry.first >= holding_register_size_ )
     {
-      ROS_ERROR_STREAM("Holding Register is defined from: 0 ... " << (holding_register_size_-1) << "."
+      ROS_ERROR_STREAM_NAMED("ServerMock", "Holding Register is defined from: 0 ... " << (holding_register_size_-1) << "."
                        << " Setting Register " << entry.first << " ... " << " is not possible");
       return;
     }
@@ -85,33 +85,33 @@ void PilzModbusServerMock::setHoldingRegister(std::initializer_list< std::pair<u
   }
   modbus_register_access_mutex.unlock();
 
-  ROS_DEBUG_STREAM("Modbus data for Modbus-Server set.");
+  ROS_DEBUG_STREAM_NAMED("ServerMock", "Modbus data for Modbus-Server set.");
 }
 
 void PilzModbusServerMock::setHoldingRegister(const RegCont& data, unsigned int start_index)
 {
   if ( data.empty() )
   {
-    ROS_ERROR("No data given.");
+    ROS_ERROR_NAMED("ServerMock", "No data given.");
     return;
   }
 
   if ( (start_index+data.size()) > holding_register_size_ )
   {
-    ROS_ERROR_STREAM("Holding Register is defined from: 0 ... " << (holding_register_size_-1) << "."
+    ROS_ERROR_STREAM_NAMED("ServerMock", "Holding Register is defined from: 0 ... " << (holding_register_size_-1) << "."
                      << " Setting Register " << start_index << " ... " << start_index + data.size() - 1
                      << " is not possible");
     return;
   }
 
-  ROS_DEBUG_STREAM("Set Modbus data for Modbus-Server...");
+  ROS_DEBUG_STREAM_NAMED("ServerMock", "Set Modbus data for Modbus-Server...");
   modbus_register_access_mutex.lock();
   for (size_t index = 0; index < data.size(); ++index)
   {
     mb_mapping_->tab_registers[start_index+index] = data.at(index);
   }
   modbus_register_access_mutex.unlock();
-  ROS_DEBUG_STREAM("Modbus data for Modbus-Server set.");
+  ROS_DEBUG_STREAM_NAMED("ServerMock", "Modbus data for Modbus-Server set.");
 }
 
 RegCont PilzModbusServerMock::readHoldingRegister(const RegCont::size_type start_index,
@@ -161,6 +161,7 @@ void PilzModbusServerMock::run()
   // Connect to client loop
   while (!terminate_)
   {
+    ROS_DEBUG_NAMED("ServerMock", "About to start to listen for a modbus connection");
     socket_ = modbus_tcp_listen(modbus_connection_, 1);
     // Set socket non blocking
     //fcntl(socket_, F_SETFL, O_NONBLOCK);
@@ -170,15 +171,16 @@ void PilzModbusServerMock::run()
       running_cv_.notify_one();
     }
 
-    ROS_INFO("Waiting for connection...");
+    ROS_INFO_NAMED("ServerMock", "Waiting for connection...");
     int result {-1};
     while(result < 0)
     {
       result = modbus_tcp_accept(modbus_connection_, &socket_);
+      ROS_DEBUG_NAMED("ServerMock", "Accepted new connection, result: %i", result);
 
       if(terminate_) break;
     }
-    ROS_INFO("Connection with client accepted.");
+    ROS_INFO_NAMED("ServerMock", "Connection with client accepted.");
 
     // Loop for reading
     int rc {-1};
@@ -193,7 +195,7 @@ void PilzModbusServerMock::run()
       }
       else
       {
-        ROS_INFO("Connection with client closed");
+        ROS_INFO_NAMED("ServerMock", "Connection with client closed");
         break;
       }
 
@@ -202,9 +204,10 @@ void PilzModbusServerMock::run()
     } // End reading loop
 
     close(socket_);
+    ROS_DEBUG_NAMED("ServerMock", "Socket closed");
     socket_ = -1;
   } // End connect to client loop
-  ROS_INFO("Modbus-server run loop finished.");
+  ROS_INFO_NAMED("ServerMock", "Modbus-server run loop finished.");
 
 }
 


### PR DESCRIPTION
* Create named logging for ModbusServerMock and LibModbusClient
* Change the logger level in the test (tbd: find better way)
* Was needed to find https://github.com/PilzDE/pilz_robots/issues/190 (will open PR as soon as this is done...)