### PR TITLE
Ready code for sanitizing

### DIFF
--- a/pilz_control/CMakeLists.txt
+++ b/pilz_control/CMakeLists.txt
@@ -24,6 +24,20 @@ catkin_package(
 
 add_definitions(-std=c++11)
 
+# To switch compiler see: https://stackoverflow.com/questions/7031126/switching-between-gcc-and-clang-llvm-using-cmake/12843988#12843988
+
+# Works with g++ and clang compiler (Do not forget to build with "-DCMAKE_BUILD_TYPE=DEBUG" flag)
+#set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+#set (CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+
+# Only works with clang compiler (Do not forget to build with "-DCMAKE_BUILD_TYPE=DEBUG" flag)
+#set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=memory -fsanitize-memory-track-origins")
+#set (CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=memory -fsanitize-memory-track-origins")
+
+# Only works with clang compiler (Do not forget to build with "-DCMAKE_BUILD_TYPE=DEBUG" flag)
+#set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=undefined")
+#set (CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=undefined")
+
 include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 
 ################

--- a/pilz_control/include/pilz_control/pilz_joint_trajectory_controller.h
+++ b/pilz_control/include/pilz_control/pilz_joint_trajectory_controller.h
@@ -54,7 +54,7 @@ class PilzJointTrajectoryController
 
     PilzJointTrajectoryController();
 
-    bool init(HardwareInterface* hw, ros::NodeHandle& root_nh, ros::NodeHandle& controller_nh);
+    bool init(HardwareInterface* hw, ros::NodeHandle& root_nh, ros::NodeHandle& controller_nh) override;
 
     /**
      * @brief Returns true if the controller currently is executing a trajectory. False otherwise.

--- a/prbt_hardware_support/CMakeLists.txt
+++ b/prbt_hardware_support/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
+
 project(prbt_hardware_support)
 
 find_package(catkin REQUIRED COMPONENTS
@@ -19,6 +20,20 @@ add_definitions(-std=c++11)
 add_definitions(-Wconversion) # At least this line needs to be below find_package to keep
                               #  the flag away from the gmock build
 add_definitions(-Wpedantic)
+
+# To switch compiler see: https://stackoverflow.com/questions/7031126/switching-between-gcc-and-clang-llvm-using-cmake/12843988#12843988
+
+# Works with g++ and clang compiler (Do not forget to build with "-DCMAKE_BUILD_TYPE=DEBUG" flag)
+#set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+#set (CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+
+# Only works with clang compiler (Do not forget to build with "-DCMAKE_BUILD_TYPE=DEBUG" flag)
+#set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=memory -fsanitize-memory-track-origins")
+#set (CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=memory -fsanitize-memory-track-origins")
+
+# Only works with clang compiler (Do not forget to build with "-DCMAKE_BUILD_TYPE=DEBUG" flag)
+#set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=undefined")
+#set (CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=undefined")
 
 # message generation
 add_message_files(

--- a/prbt_hardware_support/src/brake_test_executor.cpp
+++ b/prbt_hardware_support/src/brake_test_executor.cpp
@@ -30,8 +30,6 @@
 namespace prbt_hardware_support
 {
 
-static constexpr double WAIT_FOR_SERVICE_TIMEOUT_S{5.0};
-
 static const std::string EXECUTE_BRAKETEST_SERVICE_NAME{"/prbt/execute_braketest"};
 static const std::string BRAKETEST_ADAPTER_SERVICE_NAME{"/prbt/braketest_adapter_node/trigger_braketest"};
 

--- a/prbt_hardware_support/src/libmodbus_client.cpp
+++ b/prbt_hardware_support/src/libmodbus_client.cpp
@@ -36,7 +36,7 @@ LibModbusClient::~LibModbusClient()
 
 bool LibModbusClient::init(const char* ip, unsigned int port)
 {
-  modbus_connection_ = modbus_new_tcp(ip, port);
+  modbus_connection_ = modbus_new_tcp(ip, static_cast<int>(port));
 
   if (modbus_connect(modbus_connection_) == -1)
   {
@@ -60,7 +60,7 @@ unsigned long LibModbusClient::getResponseTimeoutInMs()
 {
   struct timeval response_timeout;
   modbus_get_response_timeout(modbus_connection_, &response_timeout);
-  return response_timeout.tv_sec * 1000L + (response_timeout.tv_usec  / 1000L);
+  return static_cast<unsigned long>(response_timeout.tv_sec * 1000L + (response_timeout.tv_usec  / 1000L));
 }
 
 RegCont LibModbusClient::readHoldingRegister(int addr, int nb)

--- a/prbt_hardware_support/src/pilz_modbus_client_node.cpp
+++ b/prbt_hardware_support/src/pilz_modbus_client_node.cpp
@@ -55,8 +55,8 @@ int main(int argc, char **argv)
     try
     {
       ModbusApiSpec api_spec(nh);
-      index_of_first_register = api_spec.getMinRegisterDefinition();
-      num_registers_to_read = api_spec.getMaxRegisterDefinition() - index_of_first_register + 1;
+      index_of_first_register = static_cast<int>(api_spec.getMinRegisterDefinition());
+      num_registers_to_read = static_cast<int>(api_spec.getMaxRegisterDefinition()) - static_cast<int>(index_of_first_register) + 1;
     }
     // LCOV_EXCL_START Can be ignored here, exceptions of ModbusApiSpec are tested in unittest_modbus_api_spec
     catch (const ModbusApiSpecException &ex)

--- a/prbt_hardware_support/test/integrationtests/integrationtest_brake_test_required.cpp
+++ b/prbt_hardware_support/test/integrationtests/integrationtest_brake_test_required.cpp
@@ -55,7 +55,6 @@ using ::testing::InvokeWithoutArgs;
 
 static constexpr uint16_t MODBUS_API_VERSION_VALUE {2};
 static const std::string SERVICE_BRAKETEST_REQUIRED = "/prbt/brake_test_required";
-static constexpr int DEFAULT_QUEUE_SIZE_BRAKE_TEST {1};
 
 /**
  * @brief BrakeTestRequiredIntegrationTest checks if the chain

--- a/prbt_hardware_support/test/unittests/pilz_modbus_server_mock.cpp
+++ b/prbt_hardware_support/test/unittests/pilz_modbus_server_mock.cpp
@@ -33,7 +33,7 @@ PilzModbusServerMock::PilzModbusServerMock(const unsigned int& holding_register_
   static constexpr unsigned BITS_NB                           {0x00};
   static constexpr unsigned INPUT_BITS_NB                     {0x00};
   static constexpr unsigned int INPUT_REGISTERS_NB            {0x0};
-  mb_mapping_ = modbus_mapping_new(BITS_NB, INPUT_BITS_NB, holding_register_size_, INPUT_REGISTERS_NB);
+  mb_mapping_ = modbus_mapping_new(BITS_NB, INPUT_BITS_NB, static_cast<int>(holding_register_size_), INPUT_REGISTERS_NB);
   if (mb_mapping_ == NULL)
   {
     ROS_ERROR_NAMED("ServerMock", "mb_mapping_ is NULL.");
@@ -55,7 +55,7 @@ PilzModbusServerMock::~PilzModbusServerMock()
 
 bool PilzModbusServerMock::init(const char *ip, unsigned int port)
 {
-  modbus_connection_ = modbus_new_tcp(ip, port);
+  modbus_connection_ = modbus_new_tcp(ip, static_cast<int>(port));
   if(modbus_connection_ == nullptr)
   {
     return false;

--- a/prbt_hardware_support/test/unittests/unittest_canopen_braketest_adapter.cpp
+++ b/prbt_hardware_support/test/unittests/unittest_canopen_braketest_adapter.cpp
@@ -51,7 +51,6 @@ static const std::string BRAKE_TEST_STATUS_OBJECT_INDEX{"2060sub3"};
 static const std::string NODE_NAMES_PARAMETER_NAME{"/prbt/driver/nodes"};
 static const std::string BRAKETEST_REQUIRED_NAME{"braketest_required"};
 static const std::string NODE_NAMES_PREFIX{"prbt_joint_"};
-static constexpr int NODE_COUNT{6};
 static const std::vector<size_t> NODE_TEST_SET{{0, 2, 5}};
 
 #define DEFAULT_SETUP \

--- a/prbt_ikfast_manipulator_plugin/CMakeLists.txt
+++ b/prbt_ikfast_manipulator_plugin/CMakeLists.txt
@@ -8,6 +8,20 @@ add_compile_options(-Wno-unused-parameter)
 add_compile_options(-Wno-unused-variable)
 add_compile_options(-Werror)
 
+# To switch compiler see: https://stackoverflow.com/questions/7031126/switching-between-gcc-and-clang-llvm-using-cmake/12843988#12843988
+
+# Works with g++ and clang compiler (Do not forget to build with "-DCMAKE_BUILD_TYPE=DEBUG" flag)
+#set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+#set (CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+
+# Only works with clang compiler (Do not forget to build with "-DCMAKE_BUILD_TYPE=DEBUG" flag)
+#set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=memory -fsanitize-memory-track-origins")
+#set (CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=memory -fsanitize-memory-track-origins")
+
+# Only works with clang compiler (Do not forget to build with "-DCMAKE_BUILD_TYPE=DEBUG" flag)
+#set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=undefined")
+#set (CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=undefined")
+
 # enable aligned new in gcc7+
 if(CMAKE_COMPILER_IS_GNUCXX)
   if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)


### PR DESCRIPTION
Make code ready for [sanitizing](https://github.com/google/sanitizers). 
In order to do that, I firstly fixed some bugs which are shown by the the clang compiler. Consequently, I added the CMake flags needed to active the different sanitizers. The sanitizer flags are all off by default. Only one sanitizer flag can be activate at any time. In order to use the different sanitizer, the compiler has to be switched to the clang compiler. See [here](https://stackoverflow.com/questions/7031126/switching-between-gcc-and-clang-llvm-using-cmake/12843988#12843988) how to do this. If you now run the different tests with the different sanitizer, you will see some errors. Try it out and have fun ;)