### PR TITLE
Not declaring a version for the clang-tidy executable

### DIFF
--- a/pilz_control/CMakeLists.txt
+++ b/pilz_control/CMakeLists.txt
@@ -31,13 +31,13 @@ include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 ################
 find_program(
   CLANG_TIDY_EXE
-  NAMES "clang-tidy-6.0"
+  NAMES "clang-tidy"
   DOC "Path to clang-tidy executable"
   )
 if(NOT CLANG_TIDY_EXE)
-  message(FATAL_ERROR "clang-tidy-6.0 not found.")
+  message(FATAL_ERROR "clang-tidy not found.")
 else()
-  message(STATUS "clang-tidy-6.0 found: ${CLANG_TIDY_EXE}")
+  message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
   set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
 endif()
 

--- a/pilz_testutils/CMakeLists.txt
+++ b/pilz_testutils/CMakeLists.txt
@@ -25,13 +25,13 @@ catkin_package(
 ################
 find_program(
   CLANG_TIDY_EXE
-  NAMES "clang-tidy-6.0"
+  NAMES "clang-tidy"
   DOC "Path to clang-tidy executable"
   )
 if(NOT CLANG_TIDY_EXE)
-  message(FATAL_ERROR "clang-tidy-6.0 not found.")
+  message(FATAL_ERROR "clang-tidy not found.")
 else()
-  message(STATUS "clang-tidy-6.0 found: ${CLANG_TIDY_EXE}")
+  message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
   set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
 endif()
 

--- a/prbt_gazebo/CMakeLists.txt
+++ b/prbt_gazebo/CMakeLists.txt
@@ -12,13 +12,13 @@ catkin_package()
 ################
 find_program(
   CLANG_TIDY_EXE
-  NAMES "clang-tidy-6.0"
+  NAMES "clang-tidy"
   DOC "Path to clang-tidy executable"
   )
 if(NOT CLANG_TIDY_EXE)
-  message(FATAL_ERROR "clang-tidy-6.0 not found.")
+  message(FATAL_ERROR "clang-tidy not found.")
 else()
-  message(STATUS "clang-tidy-6.0 found: ${CLANG_TIDY_EXE}")
+  message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
   set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
 endif()
 

--- a/prbt_hardware_support/CMakeLists.txt
+++ b/prbt_hardware_support/CMakeLists.txt
@@ -56,13 +56,13 @@ catkin_package(
 ################
 find_program(
   CLANG_TIDY_EXE
-  NAMES "clang-tidy-6.0"
+  NAMES "clang-tidy"
   DOC "Path to clang-tidy executable"
   )
 if(NOT CLANG_TIDY_EXE)
-  message(FATAL_ERROR "clang-tidy-6.0 not found.")
+  message(FATAL_ERROR "clang-tidy not found.")
 else()
-  message(STATUS "clang-tidy-6.0 found: ${CLANG_TIDY_EXE}")
+  message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
   set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
 endif()
 

--- a/prbt_ikfast_manipulator_plugin/CMakeLists.txt
+++ b/prbt_ikfast_manipulator_plugin/CMakeLists.txt
@@ -40,13 +40,13 @@ target_compile_options(${IKFAST_LIBRARY_NAME} PRIVATE -Wno-unused-variable)
 ################
 find_program(
   CLANG_TIDY_EXE
-  NAMES "clang-tidy-6.0"
+  NAMES "clang-tidy"
   DOC "Path to clang-tidy executable"
   )
 if(NOT CLANG_TIDY_EXE)
-  message(FATAL_ERROR "clang-tidy-6.0 not found.")
+  message(FATAL_ERROR "clang-tidy not found.")
 else()
-  message(STATUS "clang-tidy-6.0 found: ${CLANG_TIDY_EXE}")
+  message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
   set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
 endif()
 

--- a/prbt_support/CMakeLists.txt
+++ b/prbt_support/CMakeLists.txt
@@ -13,13 +13,13 @@ catkin_package(
 ################
 find_program(
   CLANG_TIDY_EXE
-  NAMES "clang-tidy-6.0"
+  NAMES "clang-tidy"
   DOC "Path to clang-tidy executable"
   )
 if(NOT CLANG_TIDY_EXE)
-  message(FATAL_ERROR "clang-tidy-6.0 not found.")
+  message(FATAL_ERROR "clang-tidy not found.")
 else()
-  message(STATUS "clang-tidy-6.0 found: ${CLANG_TIDY_EXE}")
+  message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
   set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
 endif()
 


### PR DESCRIPTION
this avoids the difference to kinetic