### PR TITLE
Not declaring a version for the clang-tidy executable (kinetic)

### DIFF
--- a/pilz_control/CMakeLists.txt
+++ b/pilz_control/CMakeLists.txt
@@ -31,13 +31,13 @@ include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 ################
 find_program(
   CLANG_TIDY_EXE
-  NAMES "clang-tidy-3.8"
+  NAMES "clang-tidy"
   DOC "Path to clang-tidy executable"
   )
 if(NOT CLANG_TIDY_EXE)
-  message(FATAL_ERROR "clang-tidy-3.8 not found.")
+  message(FATAL_ERROR "clang-tidy not found.")
 else()
-  message(STATUS "clang-tidy-3.8 found: ${CLANG_TIDY_EXE}")
+  message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
   set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
 endif()
 

--- a/pilz_testutils/CMakeLists.txt
+++ b/pilz_testutils/CMakeLists.txt
@@ -25,13 +25,13 @@ catkin_package(
 ################
 find_program(
   CLANG_TIDY_EXE
-  NAMES "clang-tidy-3.8"
+  NAMES "clang-tidy"
   DOC "Path to clang-tidy executable"
   )
 if(NOT CLANG_TIDY_EXE)
-  message(FATAL_ERROR "clang-tidy-3.8 not found.")
+  message(FATAL_ERROR "clang-tidy not found.")
 else()
-  message(STATUS "clang-tidy-3.8 found: ${CLANG_TIDY_EXE}")
+  message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
   set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
 endif()
 

--- a/prbt_gazebo/CMakeLists.txt
+++ b/prbt_gazebo/CMakeLists.txt
@@ -12,13 +12,13 @@ catkin_package()
 ################
 find_program(
   CLANG_TIDY_EXE
-  NAMES "clang-tidy-3.8"
+  NAMES "clang-tidy"
   DOC "Path to clang-tidy executable"
   )
 if(NOT CLANG_TIDY_EXE)
-  message(FATAL_ERROR "clang-tidy-3.8 not found.")
+  message(FATAL_ERROR "clang-tidy not found.")
 else()
-  message(STATUS "clang-tidy-3.8 found: ${CLANG_TIDY_EXE}")
+  message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
   set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
 endif()
 

--- a/prbt_hardware_support/CMakeLists.txt
+++ b/prbt_hardware_support/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(prbt_hardware_support)
 
+add_definitions(-Wall)
+add_definitions(-Wextra)
+add_definitions(-Wno-unused-parameter)
+add_definitions(-Werror)
+add_definitions(-std=c++11)
+
 find_package(catkin REQUIRED COMPONENTS
   canopen_chain_node
   message_filters
@@ -10,15 +16,6 @@ find_package(catkin REQUIRED COMPONENTS
   std_srvs
   sensor_msgs
 )
-
-add_definitions(-Wall)
-add_definitions(-Wextra)
-add_definitions(-Wno-unused-parameter)
-add_definitions(-Werror)
-add_definitions(-std=c++11)
-add_definitions(-Wconversion) # At least this line needs to be below find_package to keep
-                              #  the flag away from the gmock build
-add_definitions(-Wpedantic)
 
 # message generation
 add_message_files(
@@ -73,13 +70,13 @@ endif()
 include_directories(
   include
   test/include
+  ${catkin_INCLUDE_DIRS}
 )
-include_directories(SYSTEM ${catkin_INCLUDE_DIRS}) #Must be declared SYSTEM to avoid Warnings from ros system includes
-
 
 # MODBUS_ADAPTER_STO_NODE
 add_executable(modbus_adapter_sto_node
   src/modbus_adapter_sto_node.cpp
+  src/adapter_sto.cpp
   src/modbus_adapter_sto.cpp
   src/modbus_msg_sto_wrapper.cpp
 )
@@ -175,9 +172,6 @@ if(CATKIN_ENABLE_TESTING)
 
   include_directories(${pilz_testutils_INCLUDE_DIRS})
 
-  #catkin_lint: ignore_once missing_directory <-- needed for successful catkin_linting
-  include_directories(SYSTEM ${gmock_SOURCE_DIR}/include/) #Declare system to supress strict conversion errors in gmock
-
   add_rostest_gmock(unittest_update_filter
                     test/unittests/unittest_update_filter.test
                     test/unittests/unittest_update_filter.cpp
@@ -187,16 +181,16 @@ if(CATKIN_ENABLE_TESTING)
   )
   add_dependencies(unittest_update_filter ${${PROJECT_NAME}_EXPORTED_TARGETS})
 
-#  catkin_add_gtest(unittest_libmodbus_client
-#      test/unittests/unittest_libmodbus_client.cpp
-#      test/unittests/pilz_modbus_server_mock.cpp
-#      src/libmodbus_client.cpp
-#  )
-#  target_link_libraries(unittest_libmodbus_client
-#    ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
-#    modbus
-#  )
-#  add_dependencies(unittest_libmodbus_client ${${PROJECT_NAME}_EXPORTED_TARGETS})
+  catkin_add_gtest(unittest_libmodbus_client
+      test/unittests/unittest_libmodbus_client.cpp
+      test/unittests/pilz_modbus_server_mock.cpp
+      src/libmodbus_client.cpp
+  )
+  target_link_libraries(unittest_libmodbus_client
+    ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
+    modbus
+  )
+  add_dependencies(unittest_libmodbus_client ${${PROJECT_NAME}_EXPORTED_TARGETS})
 
   catkin_add_gmock(unittest_modbus_api_spec
   test/unittests/unittest_modbus_api_spec.cpp
@@ -233,6 +227,20 @@ if(CATKIN_ENABLE_TESTING)
     ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
   )
   add_dependencies(unittest_pilz_modbus_client ${${PROJECT_NAME}_EXPORTED_TARGETS})
+
+  #--- StoModbusAdapter unit test ---
+  add_rostest_gmock(unittest_modbus_adapter_sto
+   test/unittests/unittest_modbus_adapter_sto.test
+   test/unittests/unittest_modbus_adapter_sto.cpp
+   src/adapter_sto.cpp
+   src/modbus_adapter_sto.cpp
+   src/modbus_msg_sto_wrapper.cpp
+   src/modbus_msg_in_builder.cpp
+  )
+  target_link_libraries(unittest_modbus_adapter_sto
+    ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
+  )
+  #----------------------------------
 
   # --- ModbusAdapterBrakeTest unit test ---
   add_rostest_gmock(unittest_modbus_adapter_brake_test
@@ -304,39 +312,7 @@ if(CATKIN_ENABLE_TESTING)
   target_link_libraries(unittest_get_param
     ${catkin_LIBRARIES}
   )
-  #----------------------------------
-
-  # --- STOExecutor unit test ---
-  catkin_add_gmock(unittest_adapter_sto
-    test/unittests/unittest_adapter_sto.cpp
-  )
-  target_link_libraries(unittest_adapter_sto
-    ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
-  )
-  #----------------------------------
-
-  # --- ServiceClientFactory integration test ---
-  add_rostest_gmock(integrationtest_service_client_factory
-     test/integrationtests/integrationtest_service_client_factory.test
-     test/integrationtests/integrationtest_service_client_factory.cpp
-  )
-  target_link_libraries(integrationtest_service_client_factory
-    ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
-  )
-  #----------------------------------
-
-  #--- StoModbusAdapter intrgration test ---
-  add_rostest_gmock(integrationtest_modbus_adapter_sto
-    test/integrationtests/integrationtest_modbus_adapter_sto.test
-    test/integrationtests/integrationtest_modbus_adapter_sto.cpp
-    src/modbus_adapter_sto.cpp
-    src/modbus_msg_sto_wrapper.cpp
-    src/modbus_msg_in_builder.cpp
-  )
-  target_link_libraries(integrationtest_modbus_adapter_sto
-    ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
-  )
-  #----------------------------------
+#----------------------------------
 
   # --- Stop integration test ---
   add_rostest_gmock(integrationtest_stop1
@@ -354,10 +330,10 @@ if(CATKIN_ENABLE_TESTING)
 
   # --- Brake test required integration test ---
   add_rostest_gmock(integrationtest_brake_test_required
-    test/integrationtests/integrationtest_brake_test_required.test
-    test/integrationtests/integrationtest_brake_test_required.cpp
-    test/unittests/pilz_modbus_server_mock.cpp
-    src/libmodbus_client.cpp
+     test/integrationtests/integrationtest_brake_test_required.test
+     test/integrationtests/integrationtest_brake_test_required.cpp
+     test/unittests/pilz_modbus_server_mock.cpp
+     src/libmodbus_client.cpp
   )
   target_link_libraries(integrationtest_brake_test_required
     ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
@@ -366,34 +342,31 @@ if(CATKIN_ENABLE_TESTING)
   add_dependencies(integrationtest_brake_test_required ${catkin_EXPORTED_TARGETS})
   #----------------------------------
 
-  # --- Operation mode integration test ---
+  # --- Brake test required integration test ---
   add_rostest_gmock(integrationtest_operation_mode
     test/integrationtests/integrationtest_operation_mode.test
     test/integrationtests/integrationtest_operation_mode.cpp
     test/unittests/pilz_modbus_server_mock.cpp
     src/libmodbus_client.cpp
-  )
-  target_link_libraries(integrationtest_operation_mode
-    ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
-    modbus
-  )
-  add_dependencies(integrationtest_operation_mode ${catkin_EXPORTED_TARGETS})
-  #----------------------------------
+ )
+ target_link_libraries(integrationtest_operation_mode
+   ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
+   modbus
+ )
+ add_dependencies(integrationtest_operation_mode ${catkin_EXPORTED_TARGETS})
+ #----------------------------------
 
-  # --- Execute brake test integration test ---
-  add_rostest_gmock(integrationtest_execute_brake_test
-    test/integrationtests/integrationtest_execute_brake_test.test
-    test/integrationtests/integrationtest_execute_brake_test.cpp
+  # --- Trigger brake test integration test ---
+  add_rostest_gmock(integrationtest_trigger_brake_test
+    test/integrationtests/integrationtest_trigger_brake_test.test
+    test/integrationtests/integrationtest_trigger_brake_test.cpp
     test/unittests/joint_states_publisher_mock.cpp
-    test/unittests/pilz_modbus_server_mock.cpp
     test/unittests/canopen_chain_node_mock.cpp
-    src/libmodbus_client.cpp
   )
-  target_link_libraries(integrationtest_execute_brake_test
+  target_link_libraries(integrationtest_trigger_brake_test
     ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
-    modbus
   )
-  add_dependencies(integrationtest_execute_brake_test ${catkin_EXPORTED_TARGETS})
+  add_dependencies(integrationtest_trigger_brake_test ${catkin_EXPORTED_TARGETS})
 
   #--- SystemInfo unit test ---
   add_rostest_gmock(unittest_system_info

--- a/prbt_hardware_support/CMakeLists.txt
+++ b/prbt_hardware_support/CMakeLists.txt
@@ -1,12 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(prbt_hardware_support)
 
-add_definitions(-Wall)
-add_definitions(-Wextra)
-add_definitions(-Wno-unused-parameter)
-add_definitions(-Werror)
-add_definitions(-std=c++11)
-
 find_package(catkin REQUIRED COMPONENTS
   canopen_chain_node
   message_filters
@@ -16,6 +10,15 @@ find_package(catkin REQUIRED COMPONENTS
   std_srvs
   sensor_msgs
 )
+
+add_definitions(-Wall)
+add_definitions(-Wextra)
+add_definitions(-Wno-unused-parameter)
+add_definitions(-Werror)
+add_definitions(-std=c++11)
+add_definitions(-Wconversion) # At least this line needs to be below find_package to keep
+                              #  the flag away from the gmock build
+add_definitions(-Wpedantic)
 
 # message generation
 add_message_files(
@@ -53,13 +56,13 @@ catkin_package(
 ################
 find_program(
   CLANG_TIDY_EXE
-  NAMES "clang-tidy-3.8"
+  NAMES "clang-tidy"
   DOC "Path to clang-tidy executable"
   )
 if(NOT CLANG_TIDY_EXE)
-  message(FATAL_ERROR "clang-tidy-3.8 not found.")
+  message(FATAL_ERROR "clang-tidy not found.")
 else()
-  message(STATUS "clang-tidy-3.8 found: ${CLANG_TIDY_EXE}")
+  message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
   set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
 endif()
 
@@ -70,13 +73,13 @@ endif()
 include_directories(
   include
   test/include
-  ${catkin_INCLUDE_DIRS}
 )
+include_directories(SYSTEM ${catkin_INCLUDE_DIRS}) #Must be declared SYSTEM to avoid Warnings from ros system includes
+
 
 # MODBUS_ADAPTER_STO_NODE
 add_executable(modbus_adapter_sto_node
   src/modbus_adapter_sto_node.cpp
-  src/adapter_sto.cpp
   src/modbus_adapter_sto.cpp
   src/modbus_msg_sto_wrapper.cpp
 )
@@ -172,6 +175,9 @@ if(CATKIN_ENABLE_TESTING)
 
   include_directories(${pilz_testutils_INCLUDE_DIRS})
 
+  #catkin_lint: ignore_once missing_directory <-- needed for successful catkin_linting
+  include_directories(SYSTEM ${gmock_SOURCE_DIR}/include/) #Declare system to supress strict conversion errors in gmock
+
   add_rostest_gmock(unittest_update_filter
                     test/unittests/unittest_update_filter.test
                     test/unittests/unittest_update_filter.cpp
@@ -181,16 +187,16 @@ if(CATKIN_ENABLE_TESTING)
   )
   add_dependencies(unittest_update_filter ${${PROJECT_NAME}_EXPORTED_TARGETS})
 
-  catkin_add_gtest(unittest_libmodbus_client
-      test/unittests/unittest_libmodbus_client.cpp
-      test/unittests/pilz_modbus_server_mock.cpp
-      src/libmodbus_client.cpp
-  )
-  target_link_libraries(unittest_libmodbus_client
-    ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
-    modbus
-  )
-  add_dependencies(unittest_libmodbus_client ${${PROJECT_NAME}_EXPORTED_TARGETS})
+#  catkin_add_gtest(unittest_libmodbus_client
+#      test/unittests/unittest_libmodbus_client.cpp
+#      test/unittests/pilz_modbus_server_mock.cpp
+#      src/libmodbus_client.cpp
+#  )
+#  target_link_libraries(unittest_libmodbus_client
+#    ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
+#    modbus
+#  )
+#  add_dependencies(unittest_libmodbus_client ${${PROJECT_NAME}_EXPORTED_TARGETS})
 
   catkin_add_gmock(unittest_modbus_api_spec
   test/unittests/unittest_modbus_api_spec.cpp
@@ -227,20 +233,6 @@ if(CATKIN_ENABLE_TESTING)
     ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
   )
   add_dependencies(unittest_pilz_modbus_client ${${PROJECT_NAME}_EXPORTED_TARGETS})
-
-  #--- StoModbusAdapter unit test ---
-  add_rostest_gmock(unittest_modbus_adapter_sto
-   test/unittests/unittest_modbus_adapter_sto.test
-   test/unittests/unittest_modbus_adapter_sto.cpp
-   src/adapter_sto.cpp
-   src/modbus_adapter_sto.cpp
-   src/modbus_msg_sto_wrapper.cpp
-   src/modbus_msg_in_builder.cpp
-  )
-  target_link_libraries(unittest_modbus_adapter_sto
-    ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
-  )
-  #----------------------------------
 
   # --- ModbusAdapterBrakeTest unit test ---
   add_rostest_gmock(unittest_modbus_adapter_brake_test
@@ -312,7 +304,39 @@ if(CATKIN_ENABLE_TESTING)
   target_link_libraries(unittest_get_param
     ${catkin_LIBRARIES}
   )
-#----------------------------------
+  #----------------------------------
+
+  # --- STOExecutor unit test ---
+  catkin_add_gmock(unittest_adapter_sto
+    test/unittests/unittest_adapter_sto.cpp
+  )
+  target_link_libraries(unittest_adapter_sto
+    ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
+  )
+  #----------------------------------
+
+  # --- ServiceClientFactory integration test ---
+  add_rostest_gmock(integrationtest_service_client_factory
+     test/integrationtests/integrationtest_service_client_factory.test
+     test/integrationtests/integrationtest_service_client_factory.cpp
+  )
+  target_link_libraries(integrationtest_service_client_factory
+    ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
+  )
+  #----------------------------------
+
+  #--- StoModbusAdapter intrgration test ---
+  add_rostest_gmock(integrationtest_modbus_adapter_sto
+    test/integrationtests/integrationtest_modbus_adapter_sto.test
+    test/integrationtests/integrationtest_modbus_adapter_sto.cpp
+    src/modbus_adapter_sto.cpp
+    src/modbus_msg_sto_wrapper.cpp
+    src/modbus_msg_in_builder.cpp
+  )
+  target_link_libraries(integrationtest_modbus_adapter_sto
+    ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
+  )
+  #----------------------------------
 
   # --- Stop integration test ---
   add_rostest_gmock(integrationtest_stop1
@@ -330,10 +354,10 @@ if(CATKIN_ENABLE_TESTING)
 
   # --- Brake test required integration test ---
   add_rostest_gmock(integrationtest_brake_test_required
-     test/integrationtests/integrationtest_brake_test_required.test
-     test/integrationtests/integrationtest_brake_test_required.cpp
-     test/unittests/pilz_modbus_server_mock.cpp
-     src/libmodbus_client.cpp
+    test/integrationtests/integrationtest_brake_test_required.test
+    test/integrationtests/integrationtest_brake_test_required.cpp
+    test/unittests/pilz_modbus_server_mock.cpp
+    src/libmodbus_client.cpp
   )
   target_link_libraries(integrationtest_brake_test_required
     ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
@@ -342,31 +366,34 @@ if(CATKIN_ENABLE_TESTING)
   add_dependencies(integrationtest_brake_test_required ${catkin_EXPORTED_TARGETS})
   #----------------------------------
 
-  # --- Brake test required integration test ---
+  # --- Operation mode integration test ---
   add_rostest_gmock(integrationtest_operation_mode
     test/integrationtests/integrationtest_operation_mode.test
     test/integrationtests/integrationtest_operation_mode.cpp
     test/unittests/pilz_modbus_server_mock.cpp
     src/libmodbus_client.cpp
- )
- target_link_libraries(integrationtest_operation_mode
-   ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
-   modbus
- )
- add_dependencies(integrationtest_operation_mode ${catkin_EXPORTED_TARGETS})
- #----------------------------------
-
-  # --- Trigger brake test integration test ---
-  add_rostest_gmock(integrationtest_trigger_brake_test
-    test/integrationtests/integrationtest_trigger_brake_test.test
-    test/integrationtests/integrationtest_trigger_brake_test.cpp
-    test/unittests/joint_states_publisher_mock.cpp
-    test/unittests/canopen_chain_node_mock.cpp
   )
-  target_link_libraries(integrationtest_trigger_brake_test
+  target_link_libraries(integrationtest_operation_mode
     ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
+    modbus
   )
-  add_dependencies(integrationtest_trigger_brake_test ${catkin_EXPORTED_TARGETS})
+  add_dependencies(integrationtest_operation_mode ${catkin_EXPORTED_TARGETS})
+  #----------------------------------
+
+  # --- Execute brake test integration test ---
+  add_rostest_gmock(integrationtest_execute_brake_test
+    test/integrationtests/integrationtest_execute_brake_test.test
+    test/integrationtests/integrationtest_execute_brake_test.cpp
+    test/unittests/joint_states_publisher_mock.cpp
+    test/unittests/pilz_modbus_server_mock.cpp
+    test/unittests/canopen_chain_node_mock.cpp
+    src/libmodbus_client.cpp
+  )
+  target_link_libraries(integrationtest_execute_brake_test
+    ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
+    modbus
+  )
+  add_dependencies(integrationtest_execute_brake_test ${catkin_EXPORTED_TARGETS})
 
   #--- SystemInfo unit test ---
   add_rostest_gmock(unittest_system_info

--- a/prbt_ikfast_manipulator_plugin/CMakeLists.txt
+++ b/prbt_ikfast_manipulator_plugin/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(prbt_ikfast_manipulator_plugin)
-
-add_compile_options(-std=c++14)
+add_compile_options(-std=c++11)
 add_compile_options(-Wall)
 add_compile_options(-Wextra)
 add_compile_options(-Wno-unused-parameter)
@@ -9,10 +8,10 @@ add_compile_options(-Wno-unused-variable)
 add_compile_options(-Werror)
 
 # enable aligned new in gcc7+
-if(CMAKE_COMPILER_IS_GNUCXX)
-  if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
+if(CMAKE_COMPILER_IS_GNUCXX) 
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0) 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -faligned-new")
-  endif()
+  endif() 
 endif()
 
 find_package(catkin REQUIRED COMPONENTS
@@ -20,20 +19,27 @@ find_package(catkin REQUIRED COMPONENTS
   pluginlib
   roscpp
   tf2_kdl
-  tf2_eigen
-  eigen_conversions
 )
-find_package(LAPACK REQUIRED)
 
-include_directories(${catkin_INCLUDE_DIRS} include)
+include_directories(${catkin_INCLUDE_DIRS})
 
-catkin_package()
+catkin_package(
+  LIBRARIES
+  CATKIN_DEPENDS
+    moveit_core
+    pluginlib
+    roscpp
+    tf2_kdl
+)
+
+include_directories(include)
 
 set(IKFAST_LIBRARY_NAME prbt_manipulator_moveit_ikfast_plugin)
+
+find_package(LAPACK REQUIRED)
+
 add_library(${IKFAST_LIBRARY_NAME} src/prbt_manipulator_ikfast_moveit_plugin.cpp)
 target_link_libraries(${IKFAST_LIBRARY_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${LAPACK_LIBRARIES})
-# suppress warnings about unused variables in OpenRave's solver code
-target_compile_options(${IKFAST_LIBRARY_NAME} PRIVATE -Wno-unused-variable)
 
 ################
 ## Clang tidy ##
@@ -66,19 +72,15 @@ if(CATKIN_ENABLE_TESTING)
 
   find_package(rostest REQUIRED)
   find_package(code_coverage REQUIRED)
-  find_package(moveit_ros_planning REQUIRED)
 
   include_directories(include ${catkin_INCLUDE_DIR})
 
-  add_rostest_gtest(unittest_${PROJECT_NAME}
-    test/unittests/tst_${PROJECT_NAME}.test
-    test/unittests/tst_${PROJECT_NAME}.cpp
+  add_rostest_gtest(unittest_prbt_ikfast_manipulator_plugin
+    test/unittests/tst_prbt_ikfast_manipulator_plugin.test
+    test/unittests/tst_prbt_ikfast_manipulator_plugin.cpp
   )
 
-  target_link_libraries(unittest_${PROJECT_NAME}
-    ${catkin_LIBRARIES}
-    ${moveit_ros_planning_LIBRARIES}
-  )
+  target_link_libraries(unittest_prbt_ikfast_manipulator_plugin ${catkin_LIBRARIES})
 
   # run: catkin_make -DENABLE_COVERAGE_TESTING=ON package_name_coverage
   if(ENABLE_COVERAGE_TESTING)

--- a/prbt_ikfast_manipulator_plugin/CMakeLists.txt
+++ b/prbt_ikfast_manipulator_plugin/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(prbt_ikfast_manipulator_plugin)
-add_compile_options(-std=c++11)
+
+add_compile_options(-std=c++14)
 add_compile_options(-Wall)
 add_compile_options(-Wextra)
 add_compile_options(-Wno-unused-parameter)
@@ -8,10 +9,10 @@ add_compile_options(-Wno-unused-variable)
 add_compile_options(-Werror)
 
 # enable aligned new in gcc7+
-if(CMAKE_COMPILER_IS_GNUCXX) 
-  if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0) 
+if(CMAKE_COMPILER_IS_GNUCXX)
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -faligned-new")
-  endif() 
+  endif()
 endif()
 
 find_package(catkin REQUIRED COMPONENTS
@@ -19,40 +20,33 @@ find_package(catkin REQUIRED COMPONENTS
   pluginlib
   roscpp
   tf2_kdl
+  tf2_eigen
+  eigen_conversions
 )
-
-include_directories(${catkin_INCLUDE_DIRS})
-
-catkin_package(
-  LIBRARIES
-  CATKIN_DEPENDS
-    moveit_core
-    pluginlib
-    roscpp
-    tf2_kdl
-)
-
-include_directories(include)
-
-set(IKFAST_LIBRARY_NAME prbt_manipulator_moveit_ikfast_plugin)
-
 find_package(LAPACK REQUIRED)
 
+include_directories(${catkin_INCLUDE_DIRS} include)
+
+catkin_package()
+
+set(IKFAST_LIBRARY_NAME prbt_manipulator_moveit_ikfast_plugin)
 add_library(${IKFAST_LIBRARY_NAME} src/prbt_manipulator_ikfast_moveit_plugin.cpp)
 target_link_libraries(${IKFAST_LIBRARY_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${LAPACK_LIBRARIES})
+# suppress warnings about unused variables in OpenRave's solver code
+target_compile_options(${IKFAST_LIBRARY_NAME} PRIVATE -Wno-unused-variable)
 
 ################
 ## Clang tidy ##
 ################
 find_program(
   CLANG_TIDY_EXE
-  NAMES "clang-tidy-3.8"
+  NAMES "clang-tidy"
   DOC "Path to clang-tidy executable"
   )
 if(NOT CLANG_TIDY_EXE)
-  message(FATAL_ERROR "clang-tidy-3.8 not found.")
+  message(FATAL_ERROR "clang-tidy not found.")
 else()
-  message(STATUS "clang-tidy-3.8 found: ${CLANG_TIDY_EXE}")
+  message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
   set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
 endif()
 
@@ -72,15 +66,19 @@ if(CATKIN_ENABLE_TESTING)
 
   find_package(rostest REQUIRED)
   find_package(code_coverage REQUIRED)
+  find_package(moveit_ros_planning REQUIRED)
 
   include_directories(include ${catkin_INCLUDE_DIR})
 
-  add_rostest_gtest(unittest_prbt_ikfast_manipulator_plugin
-    test/unittests/tst_prbt_ikfast_manipulator_plugin.test
-    test/unittests/tst_prbt_ikfast_manipulator_plugin.cpp
+  add_rostest_gtest(unittest_${PROJECT_NAME}
+    test/unittests/tst_${PROJECT_NAME}.test
+    test/unittests/tst_${PROJECT_NAME}.cpp
   )
 
-  target_link_libraries(unittest_prbt_ikfast_manipulator_plugin ${catkin_LIBRARIES})
+  target_link_libraries(unittest_${PROJECT_NAME}
+    ${catkin_LIBRARIES}
+    ${moveit_ros_planning_LIBRARIES}
+  )
 
   # run: catkin_make -DENABLE_COVERAGE_TESTING=ON package_name_coverage
   if(ENABLE_COVERAGE_TESTING)

--- a/prbt_support/CMakeLists.txt
+++ b/prbt_support/CMakeLists.txt
@@ -66,3 +66,4 @@ if(CATKIN_ENABLE_TESTING)
   roslaunch_add_file_check(launch)
 
 endif()
+

--- a/prbt_support/CMakeLists.txt
+++ b/prbt_support/CMakeLists.txt
@@ -13,13 +13,13 @@ catkin_package(
 ################
 find_program(
   CLANG_TIDY_EXE
-  NAMES "clang-tidy-3.8"
+  NAMES "clang-tidy"
   DOC "Path to clang-tidy executable"
   )
 if(NOT CLANG_TIDY_EXE)
-  message(FATAL_ERROR "clang-tidy-3.8 not found.")
+  message(FATAL_ERROR "clang-tidy not found.")
 else()
-  message(STATUS "clang-tidy-3.8 found: ${CLANG_TIDY_EXE}")
+  message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
   set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
 endif()
 
@@ -66,4 +66,3 @@ if(CATKIN_ENABLE_TESTING)
   roslaunch_add_file_check(launch)
 
 endif()
-


### PR DESCRIPTION
This avoid the difference between melodich (https://github.com/PilzDE/pilz_robots/pull/219) and kinetic