### PR TITLE
Constructor of filter_pipeline failing quickly

### DIFF
--- a/prbt_hardware_support/include/prbt_hardware_support/filter_pipeline.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/filter_pipeline.h
@@ -58,12 +58,12 @@ private:
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 inline FilterPipeline::FilterPipeline(ros::NodeHandle& nh, TCallbackFunc callback_func)
 {
-  modbus_read_sub_ = std::make_shared< message_filters::Subscriber<ModbusMsgInStamped> >(nh, TOPIC_MODBUS_READ, 1);
-  update_filter_ = std::make_shared< message_filters::UpdateFilter<ModbusMsgInStamped> >(*modbus_read_sub_);
   if (!callback_func)
   {
     throw std::invalid_argument("Argument \"callback_func\" must not be empty");
   }
+  modbus_read_sub_ = std::make_shared< message_filters::Subscriber<ModbusMsgInStamped> >(nh, TOPIC_MODBUS_READ, 1);
+  update_filter_ = std::make_shared< message_filters::UpdateFilter<ModbusMsgInStamped> >(*modbus_read_sub_);
   update_filter_->registerCallback(callback_func);
 }
 


### PR DESCRIPTION
This may help with sporadic test failures.

The assumption is, that the test fails because something regarding the initialization of the node takes very long or fails and the test timeouts. 
Even if this is not the case for the test failure, this would still speed up the test. All it is testing is the throwing of the exception.

If it does not help we can still think about testing this in a system test, where the node is spun up anyway. This would also make it quicker.