### PR TITLE
Fix sto spec

### DIFF
--- a/prbt_hardware_support/spec.dox
+++ b/prbt_hardware_support/spec.dox
@@ -30,26 +30,11 @@
  * @note STO == 1/TRUE  <-> manipulator is allowed to move freely
  * @note STO == 0/FALSE <-> manipulator is NOT allowed to move (except for stop motion)
  *
- * @note A Stop 1 consists of holding the controller and halting the drives afterwards.
- *  - Holding the controller starts with performing a stop motion (possibly replacing other prevailing motions).
- *  - As long as the controller is holded, no new motions can be performed.
- *
- * @note The term "recovering" in the following section refers to a pending call on the respective service.
- *
- * @definereq{Stop1_Trigger}
- *  - A Stop 1 is triggered, if at least one of the following cases is true:
- *    - the state of the STO changes from TRUE -> FALSE (given that the
- *      drives are currently not recovering, see \refspec{release_of_stop1}),
- *    - connection to safety controller is lost,
- *    - the messages informing about the STO (coming from the
- *      safety controller) is incomplete or in any way corrupted,
- *    - the communication protocol used by the safety controller
- *      does not fulfill the expected specification
- *      (defined by the version of the protocol).
- *
  * @definereq{execution_of_stop1}
- * - If a stop1 is triggered, the system performs the following steps:
+ * - The execution of a Stop1 consists of the following steps:
  * Controller:hold (includes execution of Stop1 trajectory) -> Driver:halt
+ *
+ * - If a release_of_stop1 is in progress, the Stop1 is executed as soon as the release_of_stop1 has finished.
  *
  * - If the hold step fails, the system still tries to execute the halt service.
  *    (see also \refspec{hold_service_fail})
@@ -59,15 +44,26 @@
  * - The stop1 process cannot be interrupted, even if the STO changes to TRUE.
  *
  * @definereq{release_of_stop1}
- * - If a stop1 is released, the system performs the following steps:
+ * - The release of a Stop1 consists of the following steps:
  * Driver:recover -> Controller:unhold
  *
- * - If the STO changes to FALSE during the execution of the stop1-release process,
- * the system stops the stop1-release process as soon as the currently active step
- * is finished.
+ * - If a execution_of_stop1 is in progress, the Stop1 is released as soon as the execution_of_stop1 has finished.
  *
- * - If the recover step fails, the system ends the stop1-release process.
- *    (see also \refspec{unhold_service_fails})
+ * @definereq{release_of_stop1_interrupt}
+ * - The system ends the release of the Stop1 after the recover step in the following cases:
+ *   - If a execution_of_stop1 is triggered during the recover step,
+ *   - If the recover step fails.
+ *
+ * @definereq{Stop1_Trigger}
+ *  - The execution of a Stop 1 is triggered, if at least one of the following cases is true:
+ *    - the state of the STO changes from TRUE -> FALSE
+ *    - connection to safety controller is lost,
+ *    - the messages informing about the STO (coming from the
+ *      safety controller) is incomplete or in any way corrupted,
+ *    - the communication protocol used by the safety controller
+ *      does not fulfill the expected specification
+ *      (defined by the version of the protocol).
+ *  - The release of a Stop 1 is triggered, if the state of the STO changes from FALSE -> TRUE
  *
  *
  * @definereq{unhold_service_fails}

--- a/prbt_hardware_support/spec.dox
+++ b/prbt_hardware_support/spec.dox
@@ -54,19 +54,12 @@
  * - If the hold step fails, the system still tries to execute the halt service.
  *    (see also \refspec{hold_service_fail})
  *
- * - If the STO changes to TRUE during the execution of the stop1 process, the
- * system stops the stop1 process as soon as the currently active step is finished.
- * For example:
- *    If the state of the STO changes from TRUE -> FALSE while the drives
- *    are recovering, the controller is kept in "holding" mode and
- *    the execution of the stop trajectory is skipped.
- *
  * Please note:
  * - While the controller is holded, the controller rejects all new trajectories.
- * - The stop1 process can also be resumed by again chainging the STO to FALSE.
+ * - The stop1 process cannot be interrupted, even if the STO changes to TRUE.
  *
  * @definereq{release_of_stop1}
- * - If a stop1 is released, the system performs the follwing steps:
+ * - If a stop1 is released, the system performs the following steps:
  * Driver:recover -> Controller:unhold
  *
  * - If the STO changes to FALSE during the execution of the stop1-release process,
@@ -75,10 +68,6 @@
  *
  * - If the recover step fails, the system ends the stop1-release process.
  *    (see also \refspec{unhold_service_fails})
- *
- * Please note:
- * - The stop1-release process can also be resumed by again chainging the
- * STO to TRUE.
  *
  *
  * @definereq{unhold_service_fails}


### PR DESCRIPTION
* a stop1 always is always completely executed
* stop1-release cannot be resumed (due to above requirement)

These specifications are already fullfilled by the current implementation.