### PR TITLE
Make clang-tidy warnings errors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,21 +14,21 @@ Checks:          '-*,
                   readability-container-size-empty,
                   readability-identifier-naming,
                   '
-# WarningsAsErrors: '
-#                   performance-*,
-#                   llvm-namespace-comment,
-#                   modernize-redundant-void-arg,
-#                   modernize-use-nullptr,
-#                   modernize-use-default,
-#                   modernize-use-override,
-#                   modernize-loop-convert,
-#                   readability-named-parameter,
-#                   readability-redundant-smartptr-get,
-#                   readability-redundant-string-cstr,
-#                   readability-simplify-boolean-expr,
-#                   readability-container-size-empty,
-#                   readability-identifier-naming,
-#                   '
+WarningsAsErrors: '
+                  performance-*,
+                  llvm-namespace-comment,
+                  modernize-redundant-void-arg,
+                  modernize-use-nullptr,
+                  modernize-use-default,
+                  modernize-use-override,
+                  modernize-loop-convert,
+                  readability-named-parameter,
+                  readability-redundant-smartptr-get,
+                  readability-redundant-string-cstr,
+                  readability-simplify-boolean-expr,
+                  readability-container-size-empty,
+                  readability-identifier-naming,
+                  '
 
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
   global:
     - ROS_DISTRO="melodic"
     - CATKIN_LINT=true
+    - ADDITIONAL_DEBS="libclang-dev"
   matrix:
     - ROS_REPO=ros
     - ROS_REPO=testing


### PR DESCRIPTION
Yet I think headers are not check sufficiently.