### PR TITLE
Fix generated headers exclude for coverage

### DIFF
--- a/prbt_hardware_support/CMakeLists.txt
+++ b/prbt_hardware_support/CMakeLists.txt
@@ -437,7 +437,7 @@ if(CATKIN_ENABLE_TESTING)
     APPEND_COVERAGE_COMPILER_FLAGS()
     set(COVERAGE_EXCLUDES
         "*/${PROJECT_NAME}/test*"
-        "*/.private/${PROJECT_NAME}/include/${PROJECT_NAME}/*.h")
+        "*/devel/include/${PROJECT_NAME}/*.h")
     add_code_coverage(
       NAME ${PROJECT_NAME}_coverage
       DEPENDS tests


### PR DESCRIPTION
As I understand it, `/devel/include/${PROJECT_NAME}` is where generated headers are usually located. The previous wildcard didn't work for me.