### PR TITLE
Increase modbus response timeout for testing

### DIFF
--- a/prbt_hardware_support/test/integrationtests/integrationtest_brake_test_required.test
+++ b/prbt_hardware_support/test/integrationtests/integrationtest_brake_test_required.test
@@ -28,6 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <node name="pilz_modbus_client_node" pkg="prbt_hardware_support" type="pilz_modbus_client_node">
   <param name="modbus_server_ip" value="$(arg modbus_server_ip)"/>
   <param name="modbus_server_port" value="$(arg modbus_server_port)"/>
+  <param name="modbus_response_timeout" value="100"/>
 </node>
 <node name="modbus_adapter_brake_test_node" pkg="prbt_hardware_support" type="modbus_adapter_brake_test_node" />
 

--- a/prbt_hardware_support/test/integrationtests/integrationtest_execute_brake_test.test
+++ b/prbt_hardware_support/test/integrationtests/integrationtest_execute_brake_test.test
@@ -33,6 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <node name="pilz_modbus_client_node" pkg="prbt_hardware_support" type="pilz_modbus_client_node">
       <param name="modbus_server_ip" value="$(arg modbus_server_ip)"/>
       <param name="modbus_server_port" value="$(arg modbus_server_port)"/>
+      <param name="modbus_response_timeout" value="100"/>
     </node>
     <test test-name="integrationtest_execute_brake_test" pkg="prbt_hardware_support" type="integrationtest_execute_brake_test">
       <param name="modbus_server_ip" value="$(arg modbus_server_ip)"/>

--- a/prbt_hardware_support/test/integrationtests/integrationtest_operation_mode.test
+++ b/prbt_hardware_support/test/integrationtests/integrationtest_operation_mode.test
@@ -27,6 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <node name="pilz_modbus_client_node" pkg="prbt_hardware_support" type="pilz_modbus_client_node">
   <param name="modbus_server_ip" value="$(arg modbus_server_ip)"/>
   <param name="modbus_server_port" value="$(arg modbus_server_port)"/>
+  <param name="modbus_response_timeout" value="100"/>
 </node>
 
 <node name="modbus_adapter_operation_mode_node" pkg="prbt_hardware_support" type="modbus_adapter_operation_mode_node">

--- a/prbt_hardware_support/test/integrationtests/integrationtest_stop1.test
+++ b/prbt_hardware_support/test/integrationtests/integrationtest_stop1.test
@@ -33,6 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <node name="pilz_modbus_client_node" pkg="prbt_hardware_support" type="pilz_modbus_client_node">
   <param name="modbus_server_ip" value="$(arg modbus_server_ip)"/>
   <param name="modbus_server_port" value="$(arg modbus_server_port)"/>
+  <param name="modbus_response_timeout" value="100"/>
 </node>
 
 <node name="modbus_adapter_sto_node" pkg="prbt_hardware_support" type="modbus_adapter_sto_node">


### PR DESCRIPTION
Investigating
http://build.ros.org/job/Mdev__pilz_robots__ubuntu_bionic_amd64/67/

I jumped on some sporadic test failures that even occur on my local machine.

I figured out, that the response timeout can simply be increased for the tests, which makes them much more stable. After all, connection stability should not be a subject of those tests.