### PR TITLE
Fix warning by change parent and child of fixed frame

### DIFF
--- a/prbt_moveit_config/config/prbt.srdf.xacro
+++ b/prbt_moveit_config/config/prbt.srdf.xacro
@@ -9,8 +9,8 @@
   
   <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an
                      external frame of reference (considered fixed with respect to the robot)-->
-  <virtual_joint name="FixedBase" type="fixed" parent_frame="world" child_link="$(arg prefix)base_link" />
-  
+  <virtual_joint name="FixedBase" type="fixed" parent_frame="$(arg prefix)base_link" child_link="world" />
+
   <!-- robot manipulator -->
   <xacro:include filename="$(find prbt_moveit_config)/config/prbt_manipulator.srdf.xacro" />
   <xacro:prbt_manipulator prefix="$(arg prefix)"/>


### PR DESCRIPTION
Should fix the
```
[ WARN] [1568358468.196619397]: Skipping virtual joint 'FixedBase' because its child frame 'prbt_base_link' does not match the URDF frame 'world'
```
at startup.