### PR TITLE
Fix/pilz modbus server mock terminate

### DIFF
--- a/prbt_hardware_support/CMakeLists.txt
+++ b/prbt_hardware_support/CMakeLists.txt
@@ -225,16 +225,16 @@ if(CATKIN_ENABLE_TESTING)
   )
   add_dependencies(unittest_update_filter ${${PROJECT_NAME}_EXPORTED_TARGETS})
 
-#  catkin_add_gtest(unittest_libmodbus_client
-#      test/unittests/unittest_libmodbus_client.cpp
-#      test/unittests/pilz_modbus_server_mock.cpp
-#      src/libmodbus_client.cpp
-#  )
-#  target_link_libraries(unittest_libmodbus_client
-#    ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
-#    modbus
-#  )
-#  add_dependencies(unittest_libmodbus_client ${${PROJECT_NAME}_EXPORTED_TARGETS})
+  catkin_add_gtest(unittest_libmodbus_client
+      test/unittests/unittest_libmodbus_client.cpp
+      test/unittests/pilz_modbus_server_mock.cpp
+      src/libmodbus_client.cpp
+  )
+  target_link_libraries(unittest_libmodbus_client
+    ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
+    modbus
+  )
+  add_dependencies(unittest_libmodbus_client ${${PROJECT_NAME}_EXPORTED_TARGETS})
 
   catkin_add_gmock(unittest_modbus_api_spec
   test/unittests/unittest_modbus_api_spec.cpp

--- a/prbt_hardware_support/src/libmodbus_client.cpp
+++ b/prbt_hardware_support/src/libmodbus_client.cpp
@@ -117,7 +117,7 @@ RegCont LibModbusClient::writeReadHoldingRegister(const int write_addr,
                                       write_addr, static_cast<int>(write_reg.size()), read_addr, read_nb);
   if (rc == -1)
   {
-    std::string err = "Failed to write and read modbus registers";
+    std::string err = "Failed to write and read modbus registers: ";
     err.append(modbus_strerror(errno));
     ROS_ERROR_STREAM_NAMED("LibModbusClient", err);
     throw ModbusExceptionDisconnect(err);

--- a/prbt_hardware_support/test/include/prbt_hardware_support/pilz_modbus_server_mock.h
+++ b/prbt_hardware_support/test/include/prbt_hardware_support/pilz_modbus_server_mock.h
@@ -90,6 +90,8 @@ public:
    */
   void terminate();
 
+  void setTerminateFlag();
+
   /**
    * @brief Allocates needed resources for running the server.
    *
@@ -151,10 +153,16 @@ private:
 
 };
 
+inline void PilzModbusServerMock::setTerminateFlag()
+{
+  ROS_INFO_NAMED("ServerMock", "Set terminate to true.");
+  terminate_ = true;
+}
+
 inline void PilzModbusServerMock::terminate()
 {
   ROS_INFO_NAMED("ServerMock", "Terminate called on ServerMock.");
-  terminate_ = true;
+  setTerminateFlag();
 
   if(thread_.joinable())
   {

--- a/prbt_hardware_support/test/include/prbt_hardware_support/pilz_modbus_server_mock.h
+++ b/prbt_hardware_support/test/include/prbt_hardware_support/pilz_modbus_server_mock.h
@@ -112,7 +112,16 @@ public:
   void run();
 
 private:
+  /**
+   * @returns True if the server is told to shutdown via Modbus msg,
+   * false otherwise.
+   */
+  bool shutdownSignalReceived();
+
+private:
   const unsigned int holding_register_size_;
+  //! Index of register for server shutdown signal
+  const unsigned int terminate_register_idx_;
 
 private:
 
@@ -137,6 +146,9 @@ private:
   static constexpr uint32_t RESPONSE_TIMEOUT_IN_SEC       {0};
   static constexpr uint32_t RESPONSE_TIMEOUT_IN_USEC      {10000};
 
+  //! Register value which indicates that server has to shutdown.
+  static constexpr uint16_t TERMINATE_SIGNAL {1};
+
 };
 
 inline void PilzModbusServerMock::terminate()
@@ -150,6 +162,11 @@ inline void PilzModbusServerMock::terminate()
     thread_.join();
     ROS_DEBUG_NAMED("ServerMock", "Waiting for worker Thread of ServerMock joined.");
   }
+}
+
+inline bool PilzModbusServerMock::shutdownSignalReceived()
+{
+  return readHoldingRegister(terminate_register_idx_, 1).back() == TERMINATE_SIGNAL;
 }
 
 }

--- a/prbt_hardware_support/test/unittests/pilz_modbus_server_mock.cpp
+++ b/prbt_hardware_support/test/unittests/pilz_modbus_server_mock.cpp
@@ -26,7 +26,8 @@ namespace prbt_hardware_support
 {
 
 PilzModbusServerMock::PilzModbusServerMock(const unsigned int& holding_register_size)
-  : holding_register_size_(holding_register_size)
+  : holding_register_size_(holding_register_size + 1) // add one register for server shutdown signal
+  , terminate_register_idx_(holding_register_size)
 {
   // Create the needed mapping
   // Please note: Only the holding register is used.
@@ -184,9 +185,11 @@ void PilzModbusServerMock::run()
 
     // Loop for reading
     int rc {-1};
-    while (!terminate_)
+    while (!terminate_ && !shutdownSignalReceived())
     {
+      ROS_INFO_NAMED("ServerMock", "Receive...");
       rc = modbus_receive(modbus_connection_, query);
+      ROS_INFO_NAMED("ServerMock", "Receive done.");
       if(rc > 0)
       {
         modbus_register_access_mutex.lock();

--- a/prbt_hardware_support/test/unittests/pilz_modbus_server_mock.cpp
+++ b/prbt_hardware_support/test/unittests/pilz_modbus_server_mock.cpp
@@ -187,9 +187,7 @@ void PilzModbusServerMock::run()
     int rc {-1};
     while (!terminate_ && !shutdownSignalReceived())
     {
-      ROS_INFO_NAMED("ServerMock", "Receive...");
       rc = modbus_receive(modbus_connection_, query);
-      ROS_INFO_NAMED("ServerMock", "Receive done.");
       if(rc > 0)
       {
         modbus_register_access_mutex.lock();

--- a/prbt_hardware_support/test/unittests/pilz_modbus_server_mock.cpp
+++ b/prbt_hardware_support/test/unittests/pilz_modbus_server_mock.cpp
@@ -160,7 +160,7 @@ void PilzModbusServerMock::run()
   uint8_t query[MODBUS_TCP_MAX_ADU_LENGTH];
 
   // Connect to client loop
-  while (!terminate_)
+  while (!terminate_ && !shutdownSignalReceived())
   {
     ROS_DEBUG_NAMED("ServerMock", "About to start to listen for a modbus connection");
     socket_ = modbus_tcp_listen(modbus_connection_, 1);

--- a/prbt_hardware_support/test/unittests/unittest_libmodbus_client.cpp
+++ b/prbt_hardware_support/test/unittests/unittest_libmodbus_client.cpp
@@ -38,8 +38,8 @@ using namespace prbt_hardware_support;
 // Each testcase should have its own port in order to avoid conflicts between them
 constexpr unsigned int START_PORT {20500};
 constexpr unsigned int END_PORT {20600};
-static unsigned int active_port_idx {0};
-static std::vector<unsigned int> ports_for_test(END_PORT - START_PORT);
+static unsigned int ACTIVE_PORT_IDX {0};
+static std::vector<unsigned int> PORTS_FOR_TEST(END_PORT - START_PORT);
 
 
 constexpr unsigned int DEFAULT_REGISTER_SIZE {514};
@@ -49,7 +49,7 @@ constexpr unsigned int DEFAULT_READ_IDX {77};
 class LibModbusClientTest : public testing::Test
 {
 public:
-  static void SetUpTestCase();
+  static void SetUpTestSuite(); // NOLINT
   void TearDown() override;
   unsigned int testPort();
 };
@@ -57,17 +57,17 @@ public:
 void LibModbusClientTest::TearDown()
 {
   // Use next port on next test
-  active_port_idx++;
+  ACTIVE_PORT_IDX++;
 }
 
 unsigned int LibModbusClientTest::testPort()
 {
-  return ports_for_test.at(active_port_idx % ports_for_test.size());
+  return PORTS_FOR_TEST.at(ACTIVE_PORT_IDX % PORTS_FOR_TEST.size());
 }
 
-void LibModbusClientTest::SetUpTestCase()
+void LibModbusClientTest::SetUpTestSuite() // NOLINT
 {
-  std::iota(ports_for_test.begin(), ports_for_test.end(), START_PORT);
+  std::iota(PORTS_FOR_TEST.begin(), PORTS_FOR_TEST.end(), START_PORT);
 }
 
 /**

--- a/prbt_hardware_support/test/unittests/unittest_libmodbus_client.cpp
+++ b/prbt_hardware_support/test/unittests/unittest_libmodbus_client.cpp
@@ -49,7 +49,7 @@ constexpr unsigned int DEFAULT_READ_IDX {77};
 class LibModbusClientTest : public testing::Test
 {
 public:
-  static void SetUpTestSuite(); // NOLINT
+  static void SetUpTestCase(); // NOLINT
   void TearDown() override;
   unsigned int testPort();
 };
@@ -65,7 +65,7 @@ unsigned int LibModbusClientTest::testPort()
   return PORTS_FOR_TEST.at(ACTIVE_PORT_IDX % PORTS_FOR_TEST.size());
 }
 
-void LibModbusClientTest::SetUpTestSuite() // NOLINT
+void LibModbusClientTest::SetUpTestCase() // NOLINT
 {
   std::iota(PORTS_FOR_TEST.begin(), PORTS_FOR_TEST.end(), START_PORT);
 }

--- a/prbt_hardware_support/test/unittests/unittest_libmodbus_client.cpp
+++ b/prbt_hardware_support/test/unittests/unittest_libmodbus_client.cpp
@@ -75,9 +75,17 @@ void LibModbusClientTest::SetUpTestCase() // NOLINT
 
 void LibModbusClientTest::shutdownModbusServer(PilzModbusServerMock* server, LibModbusClient& client)
 {
+  server->setTerminateFlag();
   RegCont reg_to_write_by_client {1};
-  client.writeReadHoldingRegister(DEFAULT_REGISTER_SIZE, reg_to_write_by_client,
-                                  DEFAULT_WRITE_IDX, DEFAULT_REGISTER_SIZE-DEFAULT_WRITE_IDX);
+  try
+  {
+    client.writeReadHoldingRegister(DEFAULT_REGISTER_SIZE, reg_to_write_by_client,
+                                    DEFAULT_WRITE_IDX, DEFAULT_REGISTER_SIZE-DEFAULT_WRITE_IDX);
+  } catch (const ModbusExceptionDisconnect& /* ex */)
+  {
+    // Tolerated exception
+  }
+
   server->terminate();
 }
 


### PR DESCRIPTION
Introduces a modbus msg which states that the modbus server has to shutdown. The newly introduced modbus msg is used to avoid the blocking of the `modbus_receive` function in PilzModbusServerMock. This PR should solve the problems discussed in PR #207.