### PR TITLE
Set proper frequency in gazebo controller

### DIFF
--- a/prbt_support/urdf/prbt_macro.xacro
+++ b/prbt_support/urdf/prbt_macro.xacro
@@ -374,6 +374,7 @@ limitations under the License.
         <robotNamespace>prbt</robotNamespace>
         <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
         <legacyModeNS>false</legacyModeNS> <!-- Only used from ros-kinetic-gazebo-ros-control 2.5.18 -->
+        <controlPeriod>0.008</controlPeriod>
       </plugin>
     </gazebo>
 


### PR DESCRIPTION
Setting the controller frequency in gazebo to 8ms which should be a better match to the real system 
makes the robot oscillate. Could this be the reason why https://github.com/PilzDE/pilz_industrial_motion/issues/213 is working fine in simulation?

Does not seem to be the first time this is a problem. See https://github.com/ros-simulation/gazebo_ros_pkgs/issues/151. On startup gazebo even issues a warning.

@jschleicher your opinion?