### PR TITLE
Rename ROS_REPO ros -> main in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - CMAKE_ARGS="-DCATKIN_ENABLE_CLANG_TIDY=true"
     - ADDITIONAL_DEBS="clang-tidy libclang-dev"
   matrix:
-    - ROS_REPO=ros
+    - ROS_REPO=main
     - ROS_REPO=testing
     - ROS_REPO="testing"
       CATKIN_LINT=false NOT_TEST_BUILD=true
@@ -28,7 +28,7 @@ env:
       DOCKER_RUN_OPTS='-e COVERAGE_PKGS="pilz_control pilz_utils prbt_hardware_support"'
 matrix:
   allow_failures:
-    - env: ROS_REPO=ros
+    - env: ROS_REPO=main
   fast_finish: true
 install:
   - git clone --depth=1 --branch master https://github.com/ros-industrial/industrial_ci.git .industrial_ci


### PR DESCRIPTION
I think it is more consistent to either use `ros` & `ros_shadow_fixed` or `main` & `testing`.