### PR TITLE
Fix CodeCoverage warnings

### DIFF
--- a/pilz_control/CMakeLists.txt
+++ b/pilz_control/CMakeLists.txt
@@ -69,7 +69,12 @@ install(FILES ${PROJECT_NAME}_plugins.xml
 if(CATKIN_ENABLE_TESTING)
 
   find_package(rostest REQUIRED)
-  find_package(code_coverage REQUIRED)
+
+  if(ENABLE_COVERAGE_TESTING)
+    find_package(code_coverage REQUIRED)
+    APPEND_COVERAGE_COMPILER_FLAGS()
+  endif()
+
 
   add_rostest_gtest(unittest_pilz_joint_trajectory_controller
     test/unittest_pilz_joint_trajectory_controller.test
@@ -83,7 +88,6 @@ if(CATKIN_ENABLE_TESTING)
 
   # run: catkin_make -DENABLE_COVERAGE_TESTING=ON package_name_coverage
   if(ENABLE_COVERAGE_TESTING)
-    include(CodeCoverage)
     APPEND_COVERAGE_COMPILER_FLAGS()
     set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*")
     add_code_coverage(

--- a/pilz_utils/CMakeLists.txt
+++ b/pilz_utils/CMakeLists.txt
@@ -62,8 +62,11 @@ install(DIRECTORY include/${PROJECT_NAME}/
 #############
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
-  find_package(code_coverage REQUIRED)
 
+  if(ENABLE_COVERAGE_TESTING)
+    find_package(code_coverage REQUIRED)
+    APPEND_COVERAGE_COMPILER_FLAGS()
+  endif()
 
   # --- getParam unit test ---
   add_rostest_gtest(unittest_get_param
@@ -97,8 +100,6 @@ if(CATKIN_ENABLE_TESTING)
 
   # to run: catkin_make -DENABLE_COVERAGE_TESTIN=ON package_name_coverage (adding -j1 recommended)
   if(ENABLE_COVERAGE_TESTING)
-    include(CodeCoverage)
-    APPEND_COVERAGE_COMPILER_FLAGS()
     set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*")
     add_code_coverage(
       NAME ${PROJECT_NAME}_coverage

--- a/prbt_hardware_support/CMakeLists.txt
+++ b/prbt_hardware_support/CMakeLists.txt
@@ -227,7 +227,12 @@ install(TARGETS
 #############
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
-  find_package(code_coverage REQUIRED)
+
+  if(ENABLE_COVERAGE_TESTING)
+    find_package(code_coverage REQUIRED)
+    APPEND_COVERAGE_COMPILER_FLAGS()
+  endif()
+
   find_package(pilz_testutils REQUIRED)
 
   include_directories(${pilz_testutils_INCLUDE_DIRS})
@@ -547,8 +552,6 @@ if(CATKIN_ENABLE_TESTING)
 
   # to run: catkin_make -DENABLE_COVERAGE_TESTING=ON package_name_coverage (adding -j1 recommended)
   if(ENABLE_COVERAGE_TESTING)
-    include(CodeCoverage)
-    APPEND_COVERAGE_COMPILER_FLAGS()
     set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*"
                           "*/BrakeTestErrorCodes.h"
                           "*/ModbusMsgInStamped.h"

--- a/prbt_ikfast_manipulator_plugin/CMakeLists.txt
+++ b/prbt_ikfast_manipulator_plugin/CMakeLists.txt
@@ -70,7 +70,12 @@ install(
 if(CATKIN_ENABLE_TESTING)
 
   find_package(rostest REQUIRED)
-  find_package(code_coverage REQUIRED)
+
+  if(ENABLE_COVERAGE_TESTING)
+    find_package(code_coverage REQUIRED)
+    APPEND_COVERAGE_COMPILER_FLAGS()
+  endif()
+
   find_package(moveit_ros_planning REQUIRED)
 
   include_directories(include ${catkin_INCLUDE_DIR})
@@ -87,8 +92,6 @@ if(CATKIN_ENABLE_TESTING)
 
   # run: catkin_make -DENABLE_COVERAGE_TESTING=ON package_name_coverage
   if(ENABLE_COVERAGE_TESTING)
-    include(CodeCoverage)
-    APPEND_COVERAGE_COMPILER_FLAGS()
     set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*")
     add_code_coverage(
       NAME ${PROJECT_NAME}_coverage


### PR DESCRIPTION
* Remove warnings from code coverage on normal builds

`catkin build` (same with catkin_make) would show something like

```
__________________________________________________________________________________________________________________________________________
Warnings   << pilz_utils:check /home/alex/catkin_ws_pilz_robots_only/logs/pilz_utils/build.check.000.log                                  
CMake Warning at /opt/ros/melodic/share/code_coverage/cmake/Modules/CodeCoverage.cmake:96 (message):
  Code coverage results with an optimised (non-Debug) build may be misleading
Call Stack (most recent call first):
  /opt/ros/melodic/share/code_coverage/cmake/code_coverage-extras.cmake:3 (include)
  /opt/ros/melodic/share/code_coverage/cmake/code_coverageConfig.cmake:222 (include)
  CMakeLists.txt:65 (find_package)


cd /home/alex/catkin_ws_pilz_robots_only/build/pilz_utils; catkin build --get-env pilz_utils | catkin env -si  /usr/bin/make cmake_check_build_system; cd -
..........................................................................................................................................
__________________________________________________________________________________________________________________________________________
Warnings   << pilz_control:check /home/alex/catkin_ws_pilz_robots_only/logs/pilz_control/build.check.000.log                              
CMake Warning at /opt/ros/melodic/share/code_coverage/cmake/Modules/CodeCoverage.cmake:96 (message):
  Code coverage results with an optimised (non-Debug) build may be misleading
Call Stack (most recent call first):
  /opt/ros/melodic/share/code_coverage/cmake/code_coverage-extras.cmake:3 (include)
  /opt/ros/melodic/share/code_coverage/cmake/code_coverageConfig.cmake:222 (include)
  CMakeLists.txt:72 (find_package)


cd /home/alex/catkin_ws_pilz_robots_only/build/pilz_control; catkin build --get-env pilz_control | catkin env -si  /usr/bin/make cmake_check_build_system; cd -
..........................................................................................................................................
Finished  <<< pilz_utils                                    [ 0.9 seconds ]                                                               
Starting  >>> prbt_hardware_support                                                                                                       
__________________________________________________________________________________________________________________________________________
Warnings   << prbt_ikfast_manipulator_plugin:check /home/alex/catkin_ws_pilz_robots_only/logs/prbt_ikfast_manipulator_plugin/build.check.000.log
CMake Warning at /opt/ros/melodic/share/code_coverage/cmake/Modules/CodeCoverage.cmake:96 (message):
  Code coverage results with an optimised (non-Debug) build may be misleading
Call Stack (most recent call first):
  /opt/ros/melodic/share/code_coverage/cmake/code_coverage-extras.cmake:3 (include)
  /opt/ros/melodic/share/code_coverage/cmake/code_coverageConfig.cmake:222 (include)
  CMakeLists.txt:73 (find_package)


cd /home/alex/catkin_ws_pilz_robots_only/build/prbt_ikfast_manipulator_plugin; catkin build --get-env prbt_ikfast_manipulator_plugin | catkin env -si  /usr/bin/make cmake_check_build_system; cd -
..........................................................................................................................................
Finished  <<< prbt_ikfast_manipulator_plugin                [ 1.2 seconds ]                                                               
Finished  <<< pilz_control                                  [ 1.4 seconds ]                                                               
__________________________________________________________________________________________________________________________________________
Warnings   << prbt_hardware_support:check /home/alex/catkin_ws_pilz_robots_only/logs/prbt_hardware_support/build.check.000.log            
CMake Warning at /opt/ros/melodic/share/code_coverage/cmake/Modules/CodeCoverage.cmake:96 (message):
  Code coverage results with an optimised (non-Debug) build may be misleading
Call Stack (most recent call first):
  /opt/ros/melodic/share/code_coverage/cmake/code_coverage-extras.cmake:3 (include)
  /opt/ros/melodic/share/code_coverage/cmake/code_coverageConfig.cmake:222 (include)
  CMakeLists.txt:230 (find_package)


cd /home/alex/catkin_ws_pilz_robots_only/build/prbt_hardware_support; catkin build --get-env prbt_hardware_support | catkin env -si  /usr/bin/make cmake_check_build_system; cd -
..........................................................................................................................................
Finished  <<< prbt_hardware_support                         [ 2.2 seconds ]                                                               
Starting  >>> pilz_status_indicator_rqt                                                                                                   
Starting  >>> prbt_support                                                                                                                
Finished  <<< pilz_status_indicator_rqt                     [ 0.2 seconds ]                                                               
Finished  <<< prbt_support                                  [ 0.2 seconds ]                                                               
Starting  >>> prbt_moveit_config                                                                                                          
Finished  <<< prbt_moveit_config                            [ 0.2 seconds ]                                                               
Starting  >>> prbt_gazebo                                                                                                                 
Finished  <<< prbt_gazebo                                   [ 2.8 seconds ]                                                               
[build] Summary: All 9 packages succeeded!                                                                                                
[build]   Ignored:   1 packages were skipped or are blacklisted.                                                                          
[build]   Warnings:  4 packages succeeded with warnings.                                                                                  
[build]   Abandoned: None.                                                                                                                
[build]   Failed:    None.                                                                                                                
[build] Runtime: 6.7 seconds total. 
```
even if no coverage is generated at all.

fixed by adapting to https://github.com/mikeferguson/code_coverage/blob/master/README.md
