### PR TITLE
Changing references to `pilz_command_planner` into `pilz_industrial_motion_planner` in moveit

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -10,45 +10,45 @@ env:
 jobs:
   build_test_main:
     name: "Build + Test with Main Repo (http://packages.ros.org/ros/ubuntu)"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - uses: 'ros-industrial/industrial_ci@master'
         env:
           ROS_REPO: main
-          ROS_DISTRO: melodic
+          ROS_DISTRO: noetic
     continue-on-error: true
 
   build_test_testing:
     name: "Build + Test with Testing Repo (http://packages.ros.org/ros-testing/ubuntu)"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - uses: 'ros-industrial/industrial_ci@master'
         env:
           ROS_REPO: testing
-          ROS_DISTRO: melodic
+          ROS_DISTRO: noetic
 
   clang-format:
-    name: "Build + Test with clang format with Testing Repo of melodic (http://packages.ros.org/ros-testing/ubuntu)"
-    runs-on: ubuntu-18.04
+    name: "Build + Test with clang format with Testing Repo of noetic (http://packages.ros.org/ros-testing/ubuntu)"
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - uses: 'ros-industrial/industrial_ci@master'
         env:
           ROS_REPO: testing
-          ROS_DISTRO: melodic
+          ROS_DISTRO: noetic
           CLANG_FORMAT_CHECK: file
 
   coverage:
-    name: "Check coverage with Testing Repo of melodic (http://packages.ros.org/ros-testing/ubuntu)"
-    runs-on: ubuntu-18.04
+    name: "Check coverage with Testing Repo of noetic (http://packages.ros.org/ros-testing/ubuntu)"
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - uses: 'ros-industrial/industrial_ci@master'
         env:
           ROS_REPO: testing
-          ROS_DISTRO: melodic
+          ROS_DISTRO: noetic
           ADDITIONAL_DEBS: git
           CATKIN_LINT: false
           NOT_TEST_BUILD: true

--- a/.github/workflows/industrial_ci_prerelease.yml
+++ b/.github/workflows/industrial_ci_prerelease.yml
@@ -4,12 +4,12 @@ on: pull_request
 
 jobs:
   prerelease:
-    name: "Build + Test with package dependencies with Testing Repo of melodic (http://packages.ros.org/ros-testing/ubuntu)"
-    runs-on: ubuntu-18.04
+    name: "Build + Test with package dependencies with Testing Repo of noetic (http://packages.ros.org/ros-testing/ubuntu)"
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - uses: 'ros-industrial/industrial_ci@master'
         env:
           PRERELEASE: true
           ROS_REPO: testing
-          ROS_DISTRO: melodic
+          ROS_DISTRO: noetic

--- a/README.md
+++ b/README.md
@@ -108,15 +108,15 @@ iface can0 can static
 2. Run `roslaunch prbt_moveit_config moveit_planning_execution.launch sim:=false pipeline:=ompl`
 3. Use the moveit Motion Planning rviz plugin to plan and execute (see simulation section; set `Velocity Scaling` to 0.1 first)
 
-Instead of OMPL use the trapezoidal motion planners of Pilz for executing industrial robot commands like PTP, LIN, etc. For this install the
-package [trapezoidal_trajectory_generation](http://wiki.ros.org/trapezoidal_trajectory_generation):
+Instead of OMPL use the industrial motion planners of Pilz for executing industrial robot commands like PTP, LIN, etc. For this install the
+package [pilz_industrial_motion_planner](http://wiki.ros.org/pilz_industrial_motion_planner):
 ```
-sudo apt install ros-kinetic-trapezoidal-trajectory-generation
+sudo apt install ros-kinetic-pilz-industrial-motion-planner
 or
-sudo apt install ros-melodic-trapezoidal-trajectory-generation
+sudo apt install ros-melodic-pilz-industrial-motion-planner
 ```
 
-then replace the pipeline in the above command by `pipeline:=trapezoidal_command_planner`.
+then replace the pipeline in the above command by `pipeline:=pilz_industrial_motion_planner`.
 
 ### Adjust expert parameters
 If you've created an application package with your own launch file as described in the

--- a/README.md
+++ b/README.md
@@ -108,12 +108,12 @@ iface can0 can static
 2. Run `roslaunch prbt_moveit_config moveit_planning_execution.launch sim:=false pipeline:=ompl`
 3. Use the moveit Motion Planning rviz plugin to plan and execute (see simulation section; set `Velocity Scaling` to 0.1 first)
 
-Instead of OMPL use the motion planners of Pilz for executing industrial robot commands like PTP, LIN, etc. For this install the
-package [pilz_trajectory_generation](http://wiki.ros.org/pilz_trajectory_generation):
+Instead of OMPL use the trapezoidal motion planners of Pilz for executing industrial robot commands like PTP, LIN, etc. For this install the
+package [trapezoidal_trajectory_generation](http://wiki.ros.org/trapezoidal_trajectory_generation):
 ```
-sudo apt install ros-kinetic-pilz-trajectory-generation
+sudo apt install ros-kinetic-trapezoidal-trajectory-generation
 or
-sudo apt install ros-melodic-pilz-trajectory-generation
+sudo apt install ros-melodic-trapezoidal-trajectory-generation
 ```
 
 then replace the pipeline in the above command by `pipeline:=trapezoidal_command_planner`.

--- a/README.md
+++ b/README.md
@@ -9,22 +9,16 @@ The meta package for the PILZ manipulator PRBT 6. Here you can find documentatio
 ### Installation
 To use the packages, you can install prebuilt packages with
 ```
-sudo apt install ros-kinetic-pilz-robots
-or
-sudo apt install ros-melodic-pilz-robots
+sudo apt install ros-$ROS_DISTRO-pilz-robots
 ```
 
 ### Build Status
 
-|   | Kinetic | Melodic |
-| ----| --------|-------- |
+|   | Kinetic | Melodic | Noetic
+| ----| --------|-------- |-------- |
 | Travis  | [![Build Status](https://travis-ci.org/PilzDE/pilz_robots.svg?branch=kinetic-devel)](https://travis-ci.org/PilzDE/pilz_robots) | [![Build Status](https://travis-ci.org/PilzDE/pilz_robots.svg?branch=melodic-devel)](https://travis-ci.org/PilzDE/pilz_robots) |
 | Buildfarm src | [![buildfarm](http://build.ros.org/buildStatus/icon?job=Ksrc_uX__pilz_robots__ubuntu_xenial__source)](http://build.ros.org/view/Ksrc_uX/job/Ksrc_uX__pilz_robots__ubuntu_xenial__source/) | [![buildfarm](http://build.ros.org/buildStatus/icon?job=Msrc_uB__pilz_robots__ubuntu_bionic__source)](http://build.ros.org/view/Msrc_uB/job/Msrc_uB__pilz_robots__ubuntu_bionic__source/) |
 | Buildfarm bin | [![buildfarm](http://build.ros.org/buildStatus/icon?job=Kbin_uX64__pilz_robots__ubuntu_xenial_amd64__binary)](http://build.ros.org/view/Kbin_uX64/job/Kbin_uX64__pilz_robots__ubuntu_xenial_amd64__binary/) | [![buildfarm](http://build.ros.org/buildStatus/icon?job=Mbin_uB64__pilz_robots__ubuntu_bionic_amd64__binary)](http://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__pilz_robots__ubuntu_bionic_amd64__binary/)|
-
-#### Branching model
-`melodic-devel` is considered to be the active development branch.
-Relevant changes are cherry-picked into `kinetic-devel` on a case-by-case basis.
 
 ### Supported hardware versions
 PRBT firmware version 1.1.0
@@ -111,9 +105,11 @@ iface can0 can static
 Instead of OMPL use the industrial motion planners of Pilz for executing industrial robot commands like PTP, LIN, etc. For this install the
 package [pilz_industrial_motion_planner](http://wiki.ros.org/pilz_industrial_motion_planner):
 ```
-sudo apt install ros-kinetic-pilz-industrial-motion-planner
+sudo apt install ros-kinetic-pilz-trajectory-generation
 or
-sudo apt install ros-melodic-pilz-industrial-motion-planner
+sudo apt install ros-melodic-pilz-trajectory-generation
+or
+sudo apt install ros-noetic-pilz-industrial-motion-planner
 ```
 
 then replace the pipeline in the above command by `pipeline:=pilz_industrial_motion_planner`.
@@ -127,9 +123,7 @@ See the comments in the [pilz_tutorials package](https://github.com/PilzDE/pilz_
 ### Running the prbt with a gripper
 Currently only the Schunk pg70 is supported. To run it, first install the package:
 ```
-sudo apt install ros-kinetic-prbt-pg70-support
-or
-sudo apt install ros-melodic-prbt-pg70-support
+sudo apt install ros-$ROS_DISTRO-prbt-pg70-support
 ```
 
 then start the robot like before but with the `gripper:=pg70` set. Both simulation and real robot work.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ or
 sudo apt install ros-melodic-pilz-trajectory-generation
 ```
 
-then replace the pipeline in the above command by `pipeline:=pilz_command_planner`.
+then replace the pipeline in the above command by `pipeline:=trapezoidal_command_planner`.
 
 ### Adjust expert parameters
 If you've created an application package with your own launch file as described in the

--- a/pilz_control/CMakeLists.txt
+++ b/pilz_control/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(pilz_control)
 
 find_package(catkin

--- a/pilz_control/include/pilz_control/pilz_joint_trajectory_controller_impl.h
+++ b/pilz_control/include/pilz_control/pilz_joint_trajectory_controller_impl.h
@@ -290,16 +290,14 @@ inline void PilzJointTrajectoryController<SegmentImpl, HardwareInterface>::updat
 {
   switch (mode_->getCurrentMode())
   {
-    case TrajProcessingMode::unhold:
-    {
+    case TrajProcessingMode::unhold: {
       if (!isPlannedUpdateOK(time_data.period) && mode_->stopEvent())
       {
         stopMotion(time_data.uptime);
       }
       return;
     }
-    case TrajProcessingMode::stopping:
-    {
+    case TrajProcessingMode::stopping: {
       // By construction of the stop trajectory we can exclude that the execution starts in the future
       if (!isTrajectoryExecuted<typename JointTrajectoryController::Segment>(curr_traj, time_data.uptime))
       {

--- a/pilz_control/include/pilz_control/pilz_joint_trajectory_controller_impl.h
+++ b/pilz_control/include/pilz_control/pilz_joint_trajectory_controller_impl.h
@@ -186,7 +186,7 @@ bool PilzJointTrajectoryController<SegmentImpl, HardwareInterface>::init(Hardwar
 template <class SegmentImpl, class HardwareInterface>
 bool PilzJointTrajectoryController<SegmentImpl, HardwareInterface>::is_executing()
 {
-  if (JointTrajectoryController::state_ != JointTrajectoryController::RUNNING)
+  if (JointTrajectoryController::state_ != JointTrajectoryController::ControllerState::RUNNING)
   {
     return false;
   }
@@ -228,7 +228,7 @@ template <class SegmentImpl, class HardwareInterface>
 bool PilzJointTrajectoryController<SegmentImpl, HardwareInterface>::handleUnHoldRequest(
     std_srvs::TriggerRequest&, std_srvs::TriggerResponse& response)
 {
-  if (JointTrajectoryController::state_ == JointTrajectoryController::RUNNING && mode_->startEvent())
+  if (JointTrajectoryController::state_ == JointTrajectoryController::ControllerState::RUNNING && mode_->startEvent())
   {
     response.message = "Unhold mode (default mode) active";
     response.success = true;

--- a/pilz_control/include/pilz_control/pilz_joint_trajectory_controller_impl.h
+++ b/pilz_control/include/pilz_control/pilz_joint_trajectory_controller_impl.h
@@ -186,7 +186,7 @@ bool PilzJointTrajectoryController<SegmentImpl, HardwareInterface>::init(Hardwar
 template <class SegmentImpl, class HardwareInterface>
 bool PilzJointTrajectoryController<SegmentImpl, HardwareInterface>::is_executing()
 {
-  if (JointTrajectoryController::state_ != JointTrajectoryController::ControllerState::RUNNING)
+  if (!JointTrajectoryController::isRunning())
   {
     return false;
   }
@@ -228,7 +228,7 @@ template <class SegmentImpl, class HardwareInterface>
 bool PilzJointTrajectoryController<SegmentImpl, HardwareInterface>::handleUnHoldRequest(
     std_srvs::TriggerRequest&, std_srvs::TriggerResponse& response)
 {
-  if (JointTrajectoryController::state_ == JointTrajectoryController::ControllerState::RUNNING && mode_->startEvent())
+  if (JointTrajectoryController::isRunning() && mode_->startEvent())
   {
     response.message = "Unhold mode (default mode) active";
     response.success = true;

--- a/pilz_control/test/pjtc_manager_mock.h
+++ b/pilz_control/test/pjtc_manager_mock.h
@@ -86,7 +86,7 @@ bool PJTCManagerMock<SegmentImpl, HWInterface>::loadController()
   controller_.reset(new Controller());
   if (controller_->init(hardware_->get<HWInterface>(), nh_, controller_nh))
   {
-    controller_->state_ = controller_->INITIALIZED;
+    controller_->state_ = controller_interface::ControllerBase::ControllerState::INITIALIZED;
     return true;
   }
   return false;
@@ -97,7 +97,7 @@ void PJTCManagerMock<SegmentImpl, HWInterface>::startController()
 {
   ros::Time current_time{ ros::Time::now() };
   controller_->starting(current_time);
-  controller_->state_ = controller_->RUNNING;
+  controller_->state_ = controller_interface::ControllerBase::ControllerState::RUNNING;
   last_update_time_ = current_time;
 }
 

--- a/pilz_control/test/pjtc_manager_mock.h
+++ b/pilz_control/test/pjtc_manager_mock.h
@@ -69,6 +69,7 @@ private:
   ros::NodeHandle nh_{ "~" };
   std::string controller_ns_;
   ros::Time last_update_time_;
+  ros::Duration last_period_;
   hardware_interface::RobotHW* hardware_;
 };
 
@@ -105,14 +106,15 @@ template <class SegmentImpl, class HWInterface>
 void PJTCManagerMock<SegmentImpl, HWInterface>::update()
 {
   ros::Time current_time{ ros::Time::now() };
-  controller_->update(current_time, current_time - last_update_time_);
+  last_period_ = current_time - last_update_time_;
   last_update_time_ = current_time;
+  controller_->update(last_update_time_, last_period_);
 }
 
 template <class SegmentImpl, class HWInterface>
 ros::Duration PJTCManagerMock<SegmentImpl, HWInterface>::getCurrentPeriod()
 {
-  return ros::Time::now() - last_update_time_;
+  return last_period_;
 }
 
 template <class SegmentImpl, class HWInterface>

--- a/pilz_control/test/robot_mock.h
+++ b/pilz_control/test/robot_mock.h
@@ -25,7 +25,7 @@
 
 constexpr unsigned int NUM_JOINTS{ 2 };
 constexpr std::array<const char*, NUM_JOINTS> JOINT_NAMES = { "shoulder_to_right_arm", "shoulder_to_left_arm" };
-constexpr double JOINT_VELOCITY_EPS{ 0.001 };
+constexpr double JOINT_VELOCITY_EPS{ 0.0001 };
 
 struct JointData
 {

--- a/pilz_control/test/unittest_pilz_joint_trajectory_controller.cpp
+++ b/pilz_control/test/unittest_pilz_joint_trajectory_controller.cpp
@@ -395,8 +395,9 @@ TEST_F(PilzJointTrajectoryControllerTest, testTrajCommandExecution)
   trajectory_command_publisher.publish(goal.trajectory);
 
   ros::Duration observation_time = getGoalDuration(goal) + ros::Duration(DEFAULT_UPDATE_PERIOD_SEC);
-  EXPECT_FALSE(
-      updateUntilRobotMotion(&robot_driver_, std::chrono::milliseconds(observation_time.toNSec() * 1000000ll)));
+  EXPECT_FALSE(updateUntilRobotMotion(&robot_driver_));  // motion would not start before goal message is received
+  progressInTime(observation_time);
+  EXPECT_FALSE(updateUntilRobotMotion(&robot_driver_));  // at this time the goal would have been reached
   BARRIER({ LOG_MSG_RECEIVED_EVENT_WARN, LOG_MSG_RECEIVED_EVENT_INFO });
 }
 

--- a/pilz_control/test/unittest_pilz_joint_trajectory_controller_is_executing.cpp
+++ b/pilz_control/test/unittest_pilz_joint_trajectory_controller_is_executing.cpp
@@ -120,7 +120,7 @@ TEST_P(PilzJointTrajectoryControllerIsExecutingTest, testFakeStart)
 {
   ASSERT_TRUE(manager_->loadController()) << "Failed to initialize the controller.";
 
-  manager_->controller_->state_ = Controller::RUNNING;
+  manager_->controller_->state_ = controller_interface::ControllerBase::ControllerState::RUNNING;
   bool is_executing_result;
   EXPECT_TRUE(invokeIsExecuting(is_executing_result));
   EXPECT_FALSE(is_executing_result) << "There should be no execution to detect";

--- a/pilz_robots/CMakeLists.txt
+++ b/pilz_robots/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(pilz_robots)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/pilz_status_indicator_rqt/CMakeLists.txt
+++ b/pilz_status_indicator_rqt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(pilz_status_indicator_rqt)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/prbt_gazebo/CMakeLists.txt
+++ b/prbt_gazebo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(prbt_gazebo)
 
 add_definitions(-std=c++11)

--- a/prbt_hardware_support/CHANGELOG.rst
+++ b/prbt_hardware_support/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for package prbt_hardware_support
 
 Forthcoming
 -----------
-* changing references from pilz_command_planner to pilz_industrial_command_planner
+* changing references from pilz_command_planner to pilz_industrial_motion_planner
 
 0.5.21 (2020-11-23)
 -------------------

--- a/prbt_hardware_support/CHANGELOG.rst
+++ b/prbt_hardware_support/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package prbt_hardware_support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* changing references from pilz_command_planner to pilz_industrial_command_planner
+
 0.5.21 (2020-11-23)
 -------------------
 * Move OperationMode msg and GetOperationMode srv to pilz_msgs

--- a/prbt_hardware_support/CMakeLists.txt
+++ b/prbt_hardware_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(prbt_hardware_support)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/prbt_hardware_support/src/libmodbus_client.cpp
+++ b/prbt_hardware_support/src/libmodbus_client.cpp
@@ -120,7 +120,7 @@ RegCont LibModbusClient::writeReadHoldingRegister(const int write_addr, const Re
   }
   RegCont read_reg(static_cast<RegCont::size_type>(read_nb));
 
-  if (static_cast<int>(write_reg.size()) > std::numeric_limits<int>::max())
+  if (write_reg.size() > static_cast<unsigned int>(std::numeric_limits<int>::max()))
   {
     throw std::invalid_argument("Argument \"write_reg\" must not exceed max value of type \"int\"");
   }

--- a/prbt_hardware_support/src/libmodbus_client.cpp
+++ b/prbt_hardware_support/src/libmodbus_client.cpp
@@ -68,17 +68,17 @@ bool LibModbusClient::init(const char* ip, unsigned int port)
 
 void LibModbusClient::setResponseTimeoutInMs(unsigned long timeout_ms)
 {
-  struct timeval response_timeout;
-  response_timeout.tv_sec = timeout_ms / 1000;
-  response_timeout.tv_usec = (timeout_ms % 1000) * 1000;
-  modbus_set_response_timeout(modbus_connection_, &response_timeout);
+  uint32_t tv_sec = static_cast<uint32_t>(timeout_ms / 1000);
+  uint32_t tv_usec = static_cast<uint32_t>((timeout_ms % 1000) * 1000);
+  modbus_set_response_timeout(modbus_connection_, tv_sec, tv_usec);
 }
 
 unsigned long LibModbusClient::getResponseTimeoutInMs()
 {
-  struct timeval response_timeout;
-  modbus_get_response_timeout(modbus_connection_, &response_timeout);
-  return static_cast<unsigned long>(response_timeout.tv_sec * 1000L + (response_timeout.tv_usec / 1000L));
+  uint32_t tv_sec;
+  uint32_t tv_usec;
+  modbus_get_response_timeout(modbus_connection_, &tv_sec, &tv_usec);
+  return static_cast<unsigned long>(tv_sec * 1000L + (tv_usec / 1000L));
 }
 
 RegCont LibModbusClient::readHoldingRegister(int addr, int nb)
@@ -120,7 +120,7 @@ RegCont LibModbusClient::writeReadHoldingRegister(const int write_addr, const Re
   }
   RegCont read_reg(static_cast<RegCont::size_type>(read_nb));
 
-  if (write_reg.size() > std::numeric_limits<int>::max())
+  if (static_cast<int>(write_reg.size()) > std::numeric_limits<int>::max())
   {
     throw std::invalid_argument("Argument \"write_reg\" must not exceed max value of type \"int\"");
   }

--- a/prbt_hardware_support/src/pilz_modbus_client.cpp
+++ b/prbt_hardware_support/src/pilz_modbus_client.cpp
@@ -169,7 +169,10 @@ void PilzModbusClient::run()
       break;
     }
 
+    // LCOV_EXCL_START
+    // The following line has no hit in the coverage report. Has to be a bug of gcov.
     ModbusMsgInStampedPtr msg{ ModbusMsgInBuilder::createDefaultModbusMsgIn(index_of_first_register,
+                                                                            // LCOV_EXCL_END
                                                                             holding_register) };
 
     // Publish the received data into ROS

--- a/prbt_hardware_support/test/acceptance_tests/acceptancetest_execute_brake_test.md
+++ b/prbt_hardware_support/test/acceptance_tests/acceptancetest_execute_brake_test.md
@@ -24,7 +24,7 @@ These acceptance tests check that the real robot system reacts to a BrakeTest se
 
 ### Test Sequence
   1. Press the acknowledge button. Make sure the green light on the power cabinet is on.
-  Run `roslaunch prbt_moveit_config moveit_planning_execution.launch sim:=False pipeline:=pilz_industrial_command_planner`
+  Run `roslaunch prbt_moveit_config moveit_planning_execution.launch sim:=False pipeline:=pilz_industrial_motion_planner`
   2. Run `rosservice call /prbt/brake_test_required`
   3. Run `rosservice call /prbt/execute_braketest`
   4. Try to perform a robot motion via Rviz during the braketest execution

--- a/prbt_hardware_support/test/acceptance_tests/acceptancetest_execute_brake_test.md
+++ b/prbt_hardware_support/test/acceptance_tests/acceptancetest_execute_brake_test.md
@@ -24,7 +24,7 @@ These acceptance tests check that the real robot system reacts to a BrakeTest se
 
 ### Test Sequence
   1. Press the acknowledge button. Make sure the green light on the power cabinet is on.
-  Run `roslaunch prbt_moveit_config moveit_planning_execution.launch sim:=False pipeline:=pilz_command_planner`
+  Run `roslaunch prbt_moveit_config moveit_planning_execution.launch sim:=False pipeline:=pilz_industrial_command_planner`
   2. Run `rosservice call /prbt/brake_test_required`
   3. Run `rosservice call /prbt/execute_braketest`
   4. Try to perform a robot motion via Rviz during the braketest execution

--- a/prbt_hardware_support/test/acceptance_tests/acceptancetest_execute_brake_test_with_gripper.md
+++ b/prbt_hardware_support/test/acceptance_tests/acceptancetest_execute_brake_test_with_gripper.md
@@ -24,7 +24,7 @@ These acceptance tests check that the real robot system reacts to a BrakeTest se
 
 ### Test Sequence
   1. Press the acknowledge button. Make sure the green light on the power cabinet is on.
-  Run `roslaunch prbt_moveit_config moveit_planning_execution.launch sim:=False pipeline:=pilz_industrial_command_planner gripper:=pg70`
+  Run `roslaunch prbt_moveit_config moveit_planning_execution.launch sim:=False pipeline:=pilz_industrial_motion_planner gripper:=pg70`
   2. Run `rosservice call /prbt/brake_test_required`
   3. Run `rosservice call /prbt/execute_braketest`
   4. Try to perform a robot motion via Rviz during the braketest execution

--- a/prbt_hardware_support/test/acceptance_tests/acceptancetest_execute_brake_test_with_gripper.md
+++ b/prbt_hardware_support/test/acceptance_tests/acceptancetest_execute_brake_test_with_gripper.md
@@ -24,7 +24,7 @@ These acceptance tests check that the real robot system reacts to a BrakeTest se
 
 ### Test Sequence
   1. Press the acknowledge button. Make sure the green light on the power cabinet is on.
-  Run `roslaunch prbt_moveit_config moveit_planning_execution.launch sim:=False pipeline:=pilz_command_planner gripper:=pg70`
+  Run `roslaunch prbt_moveit_config moveit_planning_execution.launch sim:=False pipeline:=pilz_industrial_command_planner gripper:=pg70`
   2. Run `rosservice call /prbt/brake_test_required`
   3. Run `rosservice call /prbt/execute_braketest`
   4. Try to perform a robot motion via Rviz during the braketest execution

--- a/prbt_hardware_support/test/acceptance_tests/acceptancetest_stop1.md
+++ b/prbt_hardware_support/test/acceptance_tests/acceptancetest_stop1.md
@@ -25,7 +25,7 @@ These acceptance tests check that the real robot system reacts to RUN_PERMITTED 
 ## 1. Starting while acknowledge button is pressed
 ### Test Sequence
   1. Press the acknowledge button. Make sure the green light on the power cabinet is on.
-     Run `roslaunch prbt_moveit_config moveit_planning_execution.launch sim:=False pipeline:=pilz_command_planner`
+     Run `roslaunch prbt_moveit_config moveit_planning_execution.launch sim:=False pipeline:=pilz_industrial_command_planner`
   2. Release the acknowledge button. Try to move the robot.
   3. Press the acknowledge button. Make sure the green light on the power cabinet is on and try to move the robot.
   4. Using Rviz perform a long motion during which you release the acknowledge button.
@@ -38,7 +38,7 @@ These acceptance tests check that the real robot system reacts to RUN_PERMITTED 
 ## 2. Starting without acknowledge button beeing pressed
 ### Test Sequence
   1. Do not press the acknowledge button.
-     Run `roslaunch prbt_moveit_config moveit_planning_execution.launch sim:=False pipeline:=pilz_command_planner`.
+     Run `roslaunch prbt_moveit_config moveit_planning_execution.launch sim:=False pipeline:=pilz_industrial_command_planner`.
      Try to move the robot.
   2. Press the acknowledge button. Again try to move the robot.
 

--- a/prbt_hardware_support/test/acceptance_tests/acceptancetest_stop1.md
+++ b/prbt_hardware_support/test/acceptance_tests/acceptancetest_stop1.md
@@ -25,7 +25,7 @@ These acceptance tests check that the real robot system reacts to RUN_PERMITTED 
 ## 1. Starting while acknowledge button is pressed
 ### Test Sequence
   1. Press the acknowledge button. Make sure the green light on the power cabinet is on.
-     Run `roslaunch prbt_moveit_config moveit_planning_execution.launch sim:=False pipeline:=pilz_industrial_command_planner`
+     Run `roslaunch prbt_moveit_config moveit_planning_execution.launch sim:=False pipeline:=pilz_industrial_motion_planner`
   2. Release the acknowledge button. Try to move the robot.
   3. Press the acknowledge button. Make sure the green light on the power cabinet is on and try to move the robot.
   4. Using Rviz perform a long motion during which you release the acknowledge button.
@@ -38,7 +38,7 @@ These acceptance tests check that the real robot system reacts to RUN_PERMITTED 
 ## 2. Starting without acknowledge button beeing pressed
 ### Test Sequence
   1. Do not press the acknowledge button.
-     Run `roslaunch prbt_moveit_config moveit_planning_execution.launch sim:=False pipeline:=pilz_industrial_command_planner`.
+     Run `roslaunch prbt_moveit_config moveit_planning_execution.launch sim:=False pipeline:=pilz_industrial_motion_planner`.
      Try to move the robot.
   2. Press the acknowledge button. Again try to move the robot.
 

--- a/prbt_hardware_support/test/integration_tests/integrationtest_operation_mode_setup.cpp
+++ b/prbt_hardware_support/test/integration_tests/integrationtest_operation_mode_setup.cpp
@@ -167,8 +167,8 @@ TEST_P(OperationModeSetupTest, testSpeedMonitoringActivation)
   EXPECT_TRUE(isSpeedOverrideEqualTo(test_data.expected_speed_override));
 }
 
-INSTANTIATE_TEST_CASE_P(TestActivationOfSpeedMonitoring, OperationModeSetupTest,
-                        testing::Values(OP_MODE_AUTO_TEST_DATA, OP_MODE_T1_TEST_DATA));
+INSTANTIATE_TEST_SUITE_P(TestActivationOfSpeedMonitoring, OperationModeSetupTest,
+                         testing::Values(OP_MODE_AUTO_TEST_DATA, OP_MODE_T1_TEST_DATA));
 
 }  // namespace prbt_hardware_support
 

--- a/prbt_hardware_support/test/integration_tests/integrationtest_operation_mode_setup.cpp
+++ b/prbt_hardware_support/test/integration_tests/integrationtest_operation_mode_setup.cpp
@@ -168,7 +168,7 @@ TEST_P(OperationModeSetupTest, testSpeedMonitoringActivation)
 }
 
 INSTANTIATE_TEST_CASE_P(TestActivationOfSpeedMonitoring, OperationModeSetupTest,
-                        testing::Values(OP_MODE_AUTO_TEST_DATA, OP_MODE_T1_TEST_DATA), );
+                        testing::Values(OP_MODE_AUTO_TEST_DATA, OP_MODE_T1_TEST_DATA));
 
 }  // namespace prbt_hardware_support
 

--- a/prbt_hardware_support/test/unit_tests/unittest_brake_test_utils.cpp
+++ b/prbt_hardware_support/test/unit_tests/unittest_brake_test_utils.cpp
@@ -52,7 +52,7 @@ static ::testing::AssertionResult compareJointStateMessages(const JointStateCons
     return ::testing::AssertionFailure() << "Joint numbers in joint state messages do not match.";
   }
   if (!std::equal(msg1->name.begin(), msg1->name.end(), msg2->name.begin(),
-                  [](std::string name1, std::string name2) { return name1 == name2; }))
+                  [](const std::string& name1, const std::string& name2) { return name1 == name2; }))
   {
     return ::testing::AssertionFailure() << "Joint names in joint state messages do not match.";
   }

--- a/prbt_hardware_support/test/unit_tests/unittest_libmodbus_client.cpp
+++ b/prbt_hardware_support/test/unit_tests/unittest_libmodbus_client.cpp
@@ -214,7 +214,7 @@ TEST_F(LibModbusClientTest, testNegativeNumberOfRegistersToRead)
 
 /**
  * @brief Tests that exception is thrown if the user tries
- * to call the write function with a register containing too mainy elements.
+ * to call the write function with a register containing too many elements.
  */
 TEST_F(LibModbusClientTest, testOutOfRangeRegisterSize)
 {

--- a/prbt_hardware_support/test/unit_tests/unittest_operation_mode_setup_executor.cpp
+++ b/prbt_hardware_support/test/unit_tests/unittest_operation_mode_setup_executor.cpp
@@ -299,7 +299,7 @@ TEST_P(OperationModeSetupExecutorTestSpeedOverrideNice, testSpeedOverride)
 INSTANTIATE_TEST_CASE_P(SpeedOverrideModeTests, OperationModeSetupExecutorTestSpeedOverrideNice,
                         ::testing::Values(std::pair<OperationModes::_value_type, double>(OperationModes::UNKNOWN, 0.0),
                                           std::pair<OperationModes::_value_type, double>(OperationModes::T1, 0.1),
-                                          std::pair<OperationModes::_value_type, double>(OperationModes::AUTO, 1.0)) );
+                                          std::pair<OperationModes::_value_type, double>(OperationModes::AUTO, 1.0)));
 
 }  // namespace operation_mode_setup_executor_tests
 

--- a/prbt_hardware_support/test/unit_tests/unittest_operation_mode_setup_executor.cpp
+++ b/prbt_hardware_support/test/unit_tests/unittest_operation_mode_setup_executor.cpp
@@ -296,10 +296,10 @@ TEST_P(OperationModeSetupExecutorTestSpeedOverrideNice, testSpeedOverride)
   EXPECT_EQ(res.speed_override, GetParam().second);
 }
 
-INSTANTIATE_TEST_CASE_P(SpeedOverrideModeTests, OperationModeSetupExecutorTestSpeedOverrideNice,
-                        ::testing::Values(std::pair<OperationModes::_value_type, double>(OperationModes::UNKNOWN, 0.0),
-                                          std::pair<OperationModes::_value_type, double>(OperationModes::T1, 0.1),
-                                          std::pair<OperationModes::_value_type, double>(OperationModes::AUTO, 1.0)));
+INSTANTIATE_TEST_SUITE_P(SpeedOverrideModeTests, OperationModeSetupExecutorTestSpeedOverrideNice,
+                         ::testing::Values(std::pair<OperationModes::_value_type, double>(OperationModes::UNKNOWN, 0.0),
+                                           std::pair<OperationModes::_value_type, double>(OperationModes::T1, 0.1),
+                                           std::pair<OperationModes::_value_type, double>(OperationModes::AUTO, 1.0)));
 
 }  // namespace operation_mode_setup_executor_tests
 

--- a/prbt_hardware_support/test/unit_tests/unittest_operation_mode_setup_executor.cpp
+++ b/prbt_hardware_support/test/unit_tests/unittest_operation_mode_setup_executor.cpp
@@ -299,7 +299,7 @@ TEST_P(OperationModeSetupExecutorTestSpeedOverrideNice, testSpeedOverride)
 INSTANTIATE_TEST_CASE_P(SpeedOverrideModeTests, OperationModeSetupExecutorTestSpeedOverrideNice,
                         ::testing::Values(std::pair<OperationModes::_value_type, double>(OperationModes::UNKNOWN, 0.0),
                                           std::pair<OperationModes::_value_type, double>(OperationModes::T1, 0.1),
-                                          std::pair<OperationModes::_value_type, double>(OperationModes::AUTO, 1.0)), );
+                                          std::pair<OperationModes::_value_type, double>(OperationModes::AUTO, 1.0)) );
 
 }  // namespace operation_mode_setup_executor_tests
 

--- a/prbt_hardware_support/test/unit_tests/unittest_pilz_modbus_client.cpp
+++ b/prbt_hardware_support/test/unit_tests/unittest_pilz_modbus_client.cpp
@@ -502,7 +502,7 @@ TEST_F(PilzModbusClientTests, testWritingOfHoldingRegister)
                                               expected_write_reg, REGISTER_FIRST_IDX_TEST,
                                               static_cast<int>(expected_read_reg.size())))
       .Times(1)
-      .WillOnce(DoAll(ACTION_OPEN_BARRIER_VOID("writeHoldingRegister"), Return(expected_read_reg)));
+      .WillOnce(testing::DoAll(ACTION_OPEN_BARRIER_VOID("writeHoldingRegister"), Return(expected_read_reg)));
 
   EXPECT_CALL(*this, modbus_read_cb(_)).Times(AnyNumber());
 

--- a/prbt_moveit_config/CHANGELOG.rst
+++ b/prbt_moveit_config/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for package prbt_moveit_config
 
 Forthcoming
 -----------
-* changing references from pilz_command_planner to pilz_industrial_command_planner
+* changing references from pilz_command_planner to pilz_industrial_motion_planner
 
 0.5.21 (2020-11-23)
 -------------------

--- a/prbt_moveit_config/CHANGELOG.rst
+++ b/prbt_moveit_config/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package prbt_moveit_config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* changing references from pilz_command_planner to pilz_industrial_command_planner
+
 0.5.21 (2020-11-23)
 -------------------
 * Move capabilities arguments into planning pipeline

--- a/prbt_moveit_config/CMakeLists.txt
+++ b/prbt_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(prbt_moveit_config)
 
 add_compile_options(-Wall)

--- a/prbt_moveit_config/launch/trapezoidal_command_planner_planning_pipeline.launch.xml
+++ b/prbt_moveit_config/launch/trapezoidal_command_planner_planning_pipeline.launch.xml
@@ -1,7 +1,7 @@
 <launch>
 
   <!-- Pilz Command Planner Plugin for MoveIt! -->
-  <arg name="planning_plugin" value="trapezoidal::CommandPlanner" />
+  <arg name="planning_plugin" value="pilz_industrial_motion_planner::CommandPlanner" />
 
   <!-- The request adapters (plugins) used when planning.
        ORDER MATTERS -->

--- a/prbt_moveit_config/launch/trapezoidal_command_planner_planning_pipeline.launch.xml
+++ b/prbt_moveit_config/launch/trapezoidal_command_planner_planning_pipeline.launch.xml
@@ -1,7 +1,7 @@
 <launch>
 
   <!-- Pilz Command Planner Plugin for MoveIt! -->
-  <arg name="planning_plugin" value="pilz::CommandPlanner" />
+  <arg name="planning_plugin" value="trapezoidal::CommandPlanner" />
 
   <!-- The request adapters (plugins) used when planning.
        ORDER MATTERS -->

--- a/prbt_support/CMakeLists.txt
+++ b/prbt_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(prbt_support)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/prbt_support/test/unit_tests/unittest_system_info.cpp
+++ b/prbt_support/test/unit_tests/unittest_system_info.cpp
@@ -216,7 +216,7 @@ TEST_F(SystemInfoTests, testServiceResponseFalse)
 {
   EXPECT_CALL(*this, executeGetObject(_, _))
       .Times(1)
-      .WillRepeatedly(testing::Invoke([](GetObject::Request&, GetObject::Response& res) {
+      .WillRepeatedly(testing::Invoke([](GetObject::Request& /*unused*/, GetObject::Response& res) {
         res.success = false;
         return true;
       }));
@@ -233,7 +233,8 @@ TEST_F(SystemInfoTests, testServiceFail)
 {
   EXPECT_CALL(*this, executeGetObject(_, _))
       .Times(1)
-      .WillRepeatedly(testing::Invoke([](GetObject::Request&, GetObject::Response&) { return false; }));
+      .WillRepeatedly(
+          testing::Invoke([](GetObject::Request& /*unused*/, GetObject::Response& /*unused*/) { return false; }));
 
   ros::NodeHandle nh{ "~" };
   SystemInfo info{ nh };

--- a/prbt_support/test/urdf_tests.cpp
+++ b/prbt_support/test/urdf_tests.cpp
@@ -106,7 +106,7 @@ void URDFKinematicsTest::SetUp()
       TestDataPoint("TestPos10", { 0, 0, 0, 0, 0, M_PI_2 }, Eigen::Vector3d(0, 0, L0 + L1 + L2 + L3)));
 }
 
-INSTANTIATE_TEST_CASE_P(InstantiationName, URDFKinematicsTest, ::testing::Values(PARAM_MODEL), );
+INSTANTIATE_TEST_CASE_P(InstantiationName, URDFKinematicsTest, ::testing::Values(PARAM_MODEL));
 /**
  * \brief test the kinematics of urdf model
  *

--- a/prbt_support/test/urdf_tests.cpp
+++ b/prbt_support/test/urdf_tests.cpp
@@ -106,7 +106,7 @@ void URDFKinematicsTest::SetUp()
       TestDataPoint("TestPos10", { 0, 0, 0, 0, 0, M_PI_2 }, Eigen::Vector3d(0, 0, L0 + L1 + L2 + L3)));
 }
 
-INSTANTIATE_TEST_CASE_P(InstantiationName, URDFKinematicsTest, ::testing::Values(PARAM_MODEL));
+INSTANTIATE_TEST_SUITE_P(InstantiationName, URDFKinematicsTest, ::testing::Values(PARAM_MODEL));
 /**
  * \brief test the kinematics of urdf model
  *


### PR DESCRIPTION
Follow-up after the merge of `pilz_trajectory_generation` into ros-planning/moveit as `pilz_industrial_motion_planner`.

See ros-planning/moveit#1893

Next steps:
- [x] close this p.r. once it is ready
- [x] create new branch noetic-devel and push it
- [x] add branch protection rule for noetic-devel