### PR TITLE
add pipeline for merging the planner into moveit

### DIFF
--- a/prbt_moveit_config/CHANGELOG.rst
+++ b/prbt_moveit_config/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package prbt_moveit_config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* add pipeline for merging the planner into moveit (old pipeline still available)
+* Contributors: Pilz GmbH and Co. KG
+
 0.5.13 (2019-12-04)
 -------------------
 

--- a/prbt_moveit_config/launch/move_group.launch
+++ b/prbt_moveit_config/launch/move_group.launch
@@ -28,10 +28,13 @@
   <arg name="gripper" default="" />
 
   <!-- add sequence capabilities for pilz_command_planner pipeline -->
-  <arg name="_capabilities" value="$(arg capabilities)" unless="$(eval arg('pipeline')=='pilz_command_planner')" />
+  <arg name="_capabilities" value="$(arg capabilities)" unless="$(eval arg('pipeline')=='pilz_command_planner' or arg('pipeline')=='pilz_industrial_motion_planner')" />
   <arg name="_capabilities"
        value="$(arg capabilities) pilz_trajectory_generation/MoveGroupSequenceAction pilz_trajectory_generation/MoveGroupSequenceService"
        if="$(eval arg('pipeline')=='pilz_command_planner')" />
+  <arg name="_capabilities"
+       value="$(arg capabilities) pilz_industrial_motion_planner/MoveGroupSequenceAction pilz_industrial_motion_planner/MoveGroupSequenceService"
+       if="$(eval arg('pipeline')=='pilz_industrial_motion_planner')" />
 
   <!-- load robot models -->
   <include file="$(find prbt_moveit_config)/launch/planning_context.launch" >

--- a/prbt_moveit_config/launch/pilz_industrial_motion_planner_planning_pipeline.launch.xml
+++ b/prbt_moveit_config/launch/pilz_industrial_motion_planner_planning_pipeline.launch.xml
@@ -1,0 +1,14 @@
+<launch>
+
+  <!-- Pilz Command Planner Plugin for MoveIt! -->
+  <arg name="planning_plugin" value="pilz_industrial_motion_planner::CommandPlanner" />
+
+  <arg name="planning_adapters" value="" />
+
+  <arg name="start_state_max_bounds_error" value="0.1" />
+
+  <param name="planning_plugin" value="$(arg planning_plugin)" />
+  <param name="request_adapters" value="$(arg planning_adapters)" />
+  <param name="start_state_max_bounds_error" value="$(arg start_state_max_bounds_error)" />
+
+</launch>


### PR DESCRIPTION
For the moment we have xml-files for both the old an the new pipeline in prbt_moveit_config. The old one will be replaced by a deprecation warning after the merge is complete; finally after a long enough migration time it can be removed, see #316.