### PR TITLE
Add additional build step before coverage target

### DIFF
--- a/.coverage.sh
+++ b/.coverage.sh
@@ -10,6 +10,7 @@ for pkg in $COVERAGE_PKGS; do
     echo "Creating coverage for [$pkg]"
     ws=~/target_ws
     extend="/opt/ros/$ROS_DISTRO"
+    ici_exec_in_workspace "$extend" "$ws" catkin build $pkg -v --no-deps --catkin-make-args tests
     ici_exec_in_workspace "$extend" "$ws" catkin build $pkg -v --no-deps --catkin-make-args ${pkg}_coverage
     cd $TARGET_REPO_PATH
     echo "Coverage summary for $pkg ----------------------"

--- a/pilz_utils/CMakeLists.txt
+++ b/pilz_utils/CMakeLists.txt
@@ -112,7 +112,9 @@ if(CATKIN_ENABLE_TESTING)
     set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*")
     add_code_coverage(
       NAME ${PROJECT_NAME}_coverage
-      DEPENDENCIES tests
+      # specifying dependencies in a reliable way is on open issue
+      # see https://github.com/mikeferguson/code_coverage/pull/14
+      #DEPENDENCIES tests
     )
   endif()
 endif()


### PR DESCRIPTION
To make sure the tests are built before the coverage baseline is created.
Otherwise no gcno files are found for pilz_utils since it contains only header-files.

Fixes #334 

(cherry picked from commit 7b0810a1cdedfcaafe836ae63a28e1cb7f792a57)