### PR TITLE
Move system_info_node to prbt_support

### DIFF
--- a/prbt_hardware_support/CHANGELOG.rst
+++ b/prbt_hardware_support/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog for package prbt_hardware_support
 
 Forthcoming
 -----------
+* Moved system_info_node to prbt_support
 * Adopted default configuration for launchfiles
 * Renaming of STO into RUN_PERMITTED
 * Contributors: Pilz GmbH and Co. KG

--- a/prbt_hardware_support/CMakeLists.txt
+++ b/prbt_hardware_support/CMakeLists.txt
@@ -151,15 +151,6 @@ add_executable(canopen_braketest_adapter_node
 add_dependencies(canopen_braketest_adapter_node ${catkin_EXPORTED_TARGETS} ${PROJECT_NAME}_generate_messages_cpp)
 target_link_libraries(canopen_braketest_adapter_node ${catkin_LIBRARIES})
 
-# SYSTEM_INFO_NODE
-add_executable(system_info_node
-  src/system_info_node.cpp
-  src/system_info.cpp
-  src/system_info_exception.cpp
-)
-add_dependencies(system_info_node ${catkin_EXPORTED_TARGETS} ${PROJECT_NAME}_generate_messages_cpp)
-target_link_libraries(system_info_node ${catkin_LIBRARIES})
-
 add_executable(fake_speed_override_node
   src/fake_speed_override_node.cpp
 )
@@ -217,7 +208,6 @@ install(TARGETS
   pilz_modbus_client_node
   speed_observer_node
   stop1_executor_node
-  system_info_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
@@ -489,18 +479,6 @@ if(CATKIN_ENABLE_TESTING)
     speed_observer_node
     operation_mode_setup_executor_node
     ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  )
-  #----------------------------------------
-
-  #--- SystemInfo unit test ---
-  add_rostest_gmock(unittest_system_info
-      test/unittests/unittest_system_info.test
-      test/unittests/unittest_system_info.cpp
-      src/system_info.cpp
-      src/system_info_exception.cpp
-  )
-  target_link_libraries(unittest_system_info
-    ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
   )
   #----------------------------------------
 

--- a/prbt_support/CHANGELOG.rst
+++ b/prbt_support/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog for package prbt_support
 
 Forthcoming
 -----------
+* Moved system_info_node here from prbt_hardware_support
 * Adopted default configuration for launchfiles
 * Contributors: Pilz GmbH and Co. KG
 

--- a/prbt_support/CHANGELOG.rst
+++ b/prbt_support/CHANGELOG.rst
@@ -6,6 +6,7 @@ Forthcoming
 -----------
 * Moved system_info_node here from prbt_hardware_support
 * Adopted default configuration for launchfiles
+* Add README
 * Contributors: Pilz GmbH and Co. KG
 
 0.5.14 (2020-03-11)

--- a/prbt_support/CMakeLists.txt
+++ b/prbt_support/CMakeLists.txt
@@ -1,11 +1,24 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(prbt_support)
-add_compile_options(-std=c++11)
 
-find_package(catkin REQUIRED COMPONENTS roscpp)
+find_package(catkin REQUIRED COMPONENTS
+  canopen_chain_node
+  pilz_utils
+  roscpp
+  sensor_msgs
+)
+
+add_definitions(-Wall)
+add_definitions(-Wextra)
+add_definitions(-Wno-unused-parameter)
+add_definitions(-Werror)
+add_definitions(-std=c++11)
+#add_definitions(-Wconversion) # At least this line needs to be below find_package to keep
+                              #  the flag away from the gmock build
+#add_definitions(-Wpedantic)
 
 catkin_package(
-  INCLUDE_DIRS
+  INCLUDE_DIRS include
 )
 
 ################
@@ -25,6 +38,23 @@ if(CATKIN_ENABLE_CLANG_TIDY)
   endif()
 endif()
 
+###########
+## Build ##
+###########
+
+include_directories(
+  include
+)
+
+# SYSTEM_INFO_NODE
+add_executable(system_info_node
+  src/system_info_node.cpp
+  src/system_info.cpp
+  src/system_info_exception.cpp
+)
+add_dependencies(system_info_node ${catkin_EXPORTED_TARGETS})
+target_link_libraries(system_info_node ${catkin_LIBRARIES})
+
 #############
 ## Install ##
 #############
@@ -34,6 +64,18 @@ install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 install(DIRECTORY urdf DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 install(DIRECTORY meshes DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 install(DIRECTORY config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN ".svn" EXCLUDE)
+
+install(TARGETS
+  system_info_node
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 #############
 ## Testing ##
@@ -46,11 +88,30 @@ if(CATKIN_ENABLE_TESTING)
   find_package(moveit_ros_planning REQUIRED)
   find_package(cmake_modules REQUIRED)
   find_package(Eigen3 REQUIRED)
+  find_package(pilz_testutils REQUIRED)
+
+  if(ENABLE_COVERAGE_TESTING)
+    find_package(code_coverage REQUIRED)
+    APPEND_COVERAGE_COMPILER_FLAGS()
+  endif()
 
   include_directories(
     ${catkin_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIR}
+    ${pilz_testutils_INCLUDE_DIRS}
   )
+
+  #--- SystemInfo unit test ---
+  add_rostest_gmock(unittest_system_info
+      test/unittests/unittest_system_info.test
+      test/unittests/unittest_system_info.cpp
+      src/system_info.cpp
+      src/system_info_exception.cpp
+  )
+  target_link_libraries(unittest_system_info
+    ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES}
+  )
+  #----------------------------------------
 
   add_rostest_gtest(urdf_tests
   test/urdf_tests.test
@@ -66,5 +127,14 @@ if(CATKIN_ENABLE_TESTING)
 
   find_package(roslaunch REQUIRED)
   roslaunch_add_file_check(launch)
+
+  # to run: catkin_make -DENABLE_COVERAGE_TESTING=ON package_name_coverage (adding -j1 recommended)
+  if(ENABLE_COVERAGE_TESTING)
+    set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*")
+    add_code_coverage(
+      NAME ${PROJECT_NAME}_coverage
+      DEPENDS tests
+    )
+  endif()
 
 endif()

--- a/prbt_support/CMakeLists.txt
+++ b/prbt_support/CMakeLists.txt
@@ -18,6 +18,7 @@ add_definitions(-Wconversion) # At least this line needs to be below find_packag
 add_definitions(-Wpedantic)
 
 catkin_package(
+  CATKIN_DEPENDS roscpp
   INCLUDE_DIRS include
 )
 
@@ -43,7 +44,7 @@ endif()
 ###########
 
 include_directories(
-  include
+  include ${catkin_INCLUDE_DIRS}
 )
 
 # SYSTEM_INFO_NODE
@@ -95,6 +96,7 @@ if(CATKIN_ENABLE_TESTING)
     APPEND_COVERAGE_COMPILER_FLAGS()
   endif()
 
+  #catkin_lint: ignore_once missing_directory <-- needed for successful catkin_linting
   #Declare system to supress strict compiler errors in external library headers
   include_directories(
     SYSTEM ${catkin_INCLUDE_DIRS}

--- a/prbt_support/CMakeLists.txt
+++ b/prbt_support/CMakeLists.txt
@@ -8,11 +8,11 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
 )
 
-add_definitions(-Wall)
-add_definitions(-Wextra)
-add_definitions(-Wno-unused-parameter)
-add_definitions(-Werror)
-add_definitions(-std=c++11)
+#add_definitions(-Wall)
+#add_definitions(-Wextra)
+#add_definitions(-Wno-unused-parameter)
+#add_definitions(-Werror)
+#add_definitions(-std=c++11)
 #add_definitions(-Wconversion) # At least this line needs to be below find_package to keep
                               #  the flag away from the gmock build
 #add_definitions(-Wpedantic)

--- a/prbt_support/CMakeLists.txt
+++ b/prbt_support/CMakeLists.txt
@@ -8,14 +8,14 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
 )
 
-#add_definitions(-Wall)
-#add_definitions(-Wextra)
-#add_definitions(-Wno-unused-parameter)
-#add_definitions(-Werror)
-#add_definitions(-std=c++11)
-#add_definitions(-Wconversion) # At least this line needs to be below find_package to keep
+add_definitions(-Wall)
+add_definitions(-Wextra)
+add_definitions(-Wno-unused-parameter)
+add_definitions(-Werror)
+add_definitions(-std=c++11)
+add_definitions(-Wconversion) # At least this line needs to be below find_package to keep
                               #  the flag away from the gmock build
-#add_definitions(-Wpedantic)
+add_definitions(-Wpedantic)
 
 catkin_package(
   INCLUDE_DIRS include
@@ -95,10 +95,12 @@ if(CATKIN_ENABLE_TESTING)
     APPEND_COVERAGE_COMPILER_FLAGS()
   endif()
 
+  #Declare system to supress strict compiler errors in external library headers
   include_directories(
-    ${catkin_INCLUDE_DIRS}
-    ${EIGEN3_INCLUDE_DIR}
+    SYSTEM ${catkin_INCLUDE_DIRS}
+    SYSTEM ${EIGEN3_INCLUDE_DIR}
     ${pilz_testutils_INCLUDE_DIRS}
+    SYSTEM ${gmock_SOURCE_DIR}/include/
   )
 
   #--- SystemInfo unit test ---

--- a/prbt_support/README.md
+++ b/prbt_support/README.md
@@ -11,4 +11,4 @@ Logs important system information.
 ### Used Services
 
 - /prbt/driver/get_object (canopen_chain_node/GetObject)
-  - Holds information about joint firmware.
+  - Read CANOpen object holding firmware information.

--- a/prbt_support/README.md
+++ b/prbt_support/README.md
@@ -1,0 +1,14 @@
+# Overview
+
+The prbt_support package contains files to start the PRBT manipulator. To start the robot run `roslaunch prbt_support robot.launch`.
+
+# ROS API
+
+## SystemInfoNode
+
+Logs important system information.
+
+### Used Services
+
+- /prbt/driver/get_object (canopen_chain_node/GetObject)
+  - Holds information about joint firmware.

--- a/prbt_support/include/prbt_support/system_info.h
+++ b/prbt_support/include/prbt_support/system_info.h
@@ -15,8 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef PRBT_HARDWARE_SUPPORT_SYSTEM_INFO_H
-#define PRBT_HARDWARE_SUPPORT_SYSTEM_INFO_H
+#ifndef PRBT_SUPPORT_SYSTEM_INFO_H
+#define PRBT_SUPPORT_SYSTEM_INFO_H
 
 #include <ros/ros.h>
 
@@ -26,7 +26,7 @@
 
 #include <canopen_chain_node/GetObject.h>
 
-namespace prbt_hardware_support
+namespace prbt_support
 {
 
 //! key = joint_name
@@ -64,5 +64,5 @@ private:
   ros::ServiceClient canopen_srv_get_client_;
 };
 
-} // namespace prbt_hardware_support
-#endif // PRBT_HARDWARE_SUPPORT_SYSTEM_INFO_H
+} // namespace prbt_support
+#endif // PRBT_SUPPORT_SYSTEM_INFO_H

--- a/prbt_support/include/prbt_support/system_info_exception.h
+++ b/prbt_support/include/prbt_support/system_info_exception.h
@@ -15,28 +15,24 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <ros/ros.h>
-#include <prbt_hardware_support/system_info.h>
+#ifndef PRBT_SUPPORT_SYSTEM_INFO_EXCEPTION_H
+#define PRBT_SUPPORT_SYSTEM_INFO_EXCEPTION_H
 
-using namespace prbt_hardware_support;
+#include <stdexcept>
+
+namespace prbt_support
+{
 
 /**
- * @brief Logs important system information.
+ * @brief Exception thrown by the SystemInfo class in case of an error.
  */
-// LCOV_EXCL_START
-int main(int argc, char **argv)
+class SystemInfoException : public std::runtime_error
 {
-  ros::init(argc, argv, "system_info");
-  ros::NodeHandle nh{"~"};
+public:
+  SystemInfoException(const std::string &what_arg);
+};
 
-  prbt_hardware_support::SystemInfo system_info(nh);
-  FirmwareCont versions {system_info.getFirmwareVersions()};
-  for (const auto& curr_elem : versions)
-  {
-    ROS_INFO("Firmware version [%s]: %s",
-             curr_elem.first.c_str(),
-             curr_elem.second.c_str());
-  }
-  return EXIT_SUCCESS;
+
 }
-// LCOV_EXCL_STOP
+
+#endif // PRBT_SUPPORT_SYSTEM_INFO_EXCEPTION_H

--- a/prbt_support/launch/robot.launch
+++ b/prbt_support/launch/robot.launch
@@ -94,6 +94,6 @@
         if="$(arg visual_status_indicator)" />
 
   <!-- System info node to output robot firmware version to console -->
-  <node ns="prbt" pkg="prbt_hardware_support" name="system_info_node" type="system_info_node" output="screen" />
+  <node ns="prbt" pkg="prbt_support" name="system_info_node" type="system_info_node" output="screen" />
 
 </launch>

--- a/prbt_support/package.xml
+++ b/prbt_support/package.xml
@@ -18,6 +18,9 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>roscpp</build_depend>
+  <build_depend>canopen_chain_node</build_depend>
+  <build_depend>pilz_utils</build_depend>
+  <build_depend>sensor_msgs</build_depend>
 
   <exec_depend>roscpp</exec_depend>
   <exec_depend>canopen_motor_node</exec_depend>
@@ -40,4 +43,7 @@
   <test_depend>rviz</test_depend> <!-- test_urdf.launch for acceptance test -->
   <test_depend>joint_state_publisher</test_depend> <!-- test_urdf.launch -->
   <test_depend>prbt_hardware_support</test_depend>
+  <test_depend>rosunit</test_depend>
+  <test_depend>code_coverage</test_depend>
+  <test_depend>pilz_testutils</test_depend>
 </package>

--- a/prbt_support/package.xml
+++ b/prbt_support/package.xml
@@ -17,12 +17,12 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>roscpp</build_depend>
+  <depend>roscpp</depend>
+
   <build_depend>canopen_chain_node</build_depend>
   <build_depend>pilz_utils</build_depend>
   <build_depend>sensor_msgs</build_depend>
 
-  <exec_depend>roscpp</exec_depend>
   <exec_depend>canopen_motor_node</exec_depend>
   <exec_depend>joint_state_controller</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/prbt_support/src/system_info.cpp
+++ b/prbt_support/src/system_info.cpp
@@ -32,7 +32,7 @@ static const std::string CANOPEN_GETOBJECT_SERVICE_NAME{"/prbt/driver/get_object
 static const std::string CANOPEN_NODES_PARAMETER_NAME{"/prbt/driver/nodes"};
 static const std::string JOINT_STATE_TOPIC {"/joint_states"};
 
-static const std::string GET_FIRMWARE_VERION_OBJECT{"100A"};
+static const std::string GET_FIRMWARE_VERSION_OBJECT{"100A"};
 
 // Currently the string is defined to be 41 characters long, but the last character can be omitted.
 // This is currently under investigation. See https://github.com/PilzDE/pilz_robots/issues/299.
@@ -54,7 +54,7 @@ std::string SystemInfo::getFirmwareVersionOfJoint(const std::string& joint_name)
 {
   canopen_chain_node::GetObject srv;
   srv.request.node = joint_name;
-  srv.request.object = GET_FIRMWARE_VERION_OBJECT;
+  srv.request.object = GET_FIRMWARE_VERSION_OBJECT;
   srv.request.cached = false;
 
   ROS_INFO_STREAM("Call \"get firmware\" service for \"" << joint_name << "\"");

--- a/prbt_support/src/system_info.cpp
+++ b/prbt_support/src/system_info.cpp
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <prbt_hardware_support/system_info.h>
+#include <prbt_support/system_info.h>
 
 #include <XmlRpcValue.h>
 #include <XmlRpcException.h>
@@ -23,9 +23,9 @@
 #include <pilz_utils/wait_for_service.h>
 #include <pilz_utils/wait_for_message.h>
 #include <canopen_chain_node/GetObject.h>
-#include <prbt_hardware_support/system_info_exception.h>
+#include <prbt_support/system_info_exception.h>
 
-namespace prbt_hardware_support
+namespace prbt_support
 {
 
 static const std::string CANOPEN_GETOBJECT_SERVICE_NAME{"/prbt/driver/get_object"};
@@ -100,4 +100,4 @@ std::vector<std::string> SystemInfo::getNodeNames(const ros::NodeHandle& nh)
   return node_names;
 }
 
-} // namespace prbt_hardware_support
+} // namespace prbt_support

--- a/prbt_support/src/system_info_exception.cpp
+++ b/prbt_support/src/system_info_exception.cpp
@@ -15,9 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <prbt_hardware_support/system_info_exception.h>
+#include <prbt_support/system_info_exception.h>
 
-namespace prbt_hardware_support
+namespace prbt_support
 {
 
 SystemInfoException::SystemInfoException(const std::string &what_arg)
@@ -25,4 +25,4 @@ SystemInfoException::SystemInfoException(const std::string &what_arg)
 {
 }
 
-} // prbt_hardware_support
+} // prbt_support

--- a/prbt_support/src/system_info_node.cpp
+++ b/prbt_support/src/system_info_node.cpp
@@ -15,24 +15,28 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef PRBT_HARDWARE_SUPPORT_SYSTEM_INFO_EXCEPTION_H
-#define PRBT_HARDWARE_SUPPORT_SYSTEM_INFO_EXCEPTION_H
+#include <ros/ros.h>
+#include <prbt_support/system_info.h>
 
-#include <stdexcept>
-
-namespace prbt_hardware_support
-{
+using namespace prbt_support;
 
 /**
- * @brief Exception thrown by the SystemInfo class in case of an error.
+ * @brief Logs important system information.
  */
-class SystemInfoException : public std::runtime_error
+// LCOV_EXCL_START
+int main(int argc, char **argv)
 {
-public:
-  SystemInfoException(const std::string &what_arg);
-};
+  ros::init(argc, argv, "system_info");
+  ros::NodeHandle nh{"~"};
 
-
+  prbt_support::SystemInfo system_info(nh);
+  FirmwareCont versions {system_info.getFirmwareVersions()};
+  for (const auto& curr_elem : versions)
+  {
+    ROS_INFO("Firmware version [%s]: %s",
+             curr_elem.first.c_str(),
+             curr_elem.second.c_str());
+  }
+  return EXIT_SUCCESS;
 }
-
-#endif // PRBT_HARDWARE_SUPPORT_SYSTEM_INFO_EXCEPTION_H
+// LCOV_EXCL_STOP

--- a/prbt_support/test/unittests/unittest_system_info.cpp
+++ b/prbt_support/test/unittests/unittest_system_info.cpp
@@ -31,14 +31,14 @@
 #include <pilz_utils/wait_for_message.h>
 #include <pilz_utils/wait_for_service.h>
 #include <pilz_testutils/async_test.h>
-#include <prbt_hardware_support/system_info.h>
-#include <prbt_hardware_support/system_info_exception.h>
+#include <prbt_support/system_info.h>
+#include <prbt_support/system_info_exception.h>
 
 namespace system_info_tests
 {
 
 using canopen_chain_node::GetObject;
-using namespace prbt_hardware_support;
+using namespace prbt_support;
 using namespace testing;
 
 static const std::string GET_OBJECT_TOPIC_NAME{"get_object"};

--- a/prbt_support/test/unittests/unittest_system_info.test
+++ b/prbt_support/test/unittests/unittest_system_info.test
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <launch>
 
 <test test-name="unittest_system_info"
-    pkg="prbt_hardware_support" type="unittest_system_info">
+    pkg="prbt_support" type="unittest_system_info">
 </test>
 
 </launch>


### PR DESCRIPTION
Created as per https://github.com/PilzDE/pilz_robots/pull/353#issuecomment-618282303

* Move system_info_node itself
* Move associated tests
* Add standard source-code related checks to prbt_support/CMakeLists.txt since this is the first source-code to be added
* Add new dependencies to prbt_support/package.xml
* Update Changelogs

Should we:
 [ ] Update any ReadMe?
 [ ] Remove the compiler flags that are commented out?