### PR TITLE
add missing run depend on status_indicator

### DIFF
--- a/prbt_hardware_support/package.xml
+++ b/prbt_hardware_support/package.xml
@@ -39,6 +39,7 @@
   <run_depend>std_srvs</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>pilz_msgs</run_depend>
+  <run_depend>pilz_status_indicator_rqt</run_depend>
 
   <!-- Test dependencies -->
   <test_depend>rostest</test_depend>

--- a/prbt_support/package.xml
+++ b/prbt_support/package.xml
@@ -31,7 +31,6 @@
   <exec_depend>xacro</exec_depend>
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>pilz_control</exec_depend> <!--contains the PilzJointTrajectoryController-->
-  <exec_depend>pilz_status_indicator_rqt</exec_depend>
   <exec_depend>prbt_hardware_support</exec_depend>
 
   <test_depend>rostest</test_depend>


### PR DESCRIPTION
According to roslaunch-check: [/tmp/ws/src/pilz_robots/prbt_support/launch/robot.launch]:
>	Missing package dependencies: prbt_hardware_support/package.xml: pilz_status_indicator_rqt

See test failure on [buildfarm](http://build.ros.org/job/Mdev__pilz_robots__ubuntu_bionic_amd64/126/console)