### PR TITLE
Fix/circular exec depend

### DIFF
--- a/prbt_hardware_support/launch/safety_interface.launch
+++ b/prbt_hardware_support/launch/safety_interface.launch
@@ -51,9 +51,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
              file="$(find prbt_hardware_support)/launch/operation_mode.launch" />
     <node unless="$(arg has_operation_mode_support)"
           pkg="prbt_hardware_support" name="fake_speed_override_node" type="fake_speed_override_node"/>
-  <!---->
-
-  <!-- Status Indicator -->
-  <node pkg="pilz_status_indicator_rqt" name="pilz_status_indicator_rqt" type="pilz_status_indicator_rqt"
-        if="$(arg visual_status_indicator)" />
 </launch>

--- a/prbt_hardware_support/launch/safety_interface.launch
+++ b/prbt_hardware_support/launch/safety_interface.launch
@@ -33,22 +33,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <rosparam ns="/prbt/write_api_spec" command="load" file="$(arg write_api_spec_file)" if="$(arg has_operation_mode_support)" />
 
   <!-- Open modbus connection and required modules -->
-    <!-- Modbus connection -->
-    <include file="$(find prbt_hardware_support)/launch/modbus_client.launch">
-      <arg name="modbus_server_ip" value="$(arg modbus_server_ip)" />
-    </include>
-    <!-- Run permitted -->
-    <include file="$(find prbt_hardware_support)/launch/modbus_adapter_run_permitted_node.launch" />
-    <include file="$(find prbt_hardware_support)/launch/stop1_executor_node.launch" />
+  <!-- Modbus connection -->
+  <include file="$(find prbt_hardware_support)/launch/modbus_client.launch">
+    <arg name="modbus_server_ip" value="$(arg modbus_server_ip)" />
+  </include>
+  <!-- Run permitted -->
+  <include file="$(find prbt_hardware_support)/launch/modbus_adapter_run_permitted_node.launch" />
+  <include file="$(find prbt_hardware_support)/launch/stop1_executor_node.launch" />
 
-    <!-- Brake test -->
-    <include if="$(arg has_braketest_support)" file="$(find prbt_hardware_support)/launch/brake_test.launch">
-      <arg name="write_api_spec_file" value="$(arg write_api_spec_file)" />
-    </include>
+  <!-- Brake test -->
+  <include if="$(arg has_braketest_support)" file="$(find prbt_hardware_support)/launch/brake_test.launch">
+    <arg name="write_api_spec_file" value="$(arg write_api_spec_file)" />
+  </include>
 
-    <!-- Operation Mode -->
-    <include if="$(arg has_operation_mode_support)"
-             file="$(find prbt_hardware_support)/launch/operation_mode.launch" />
-    <node unless="$(arg has_operation_mode_support)"
-          pkg="prbt_hardware_support" name="fake_speed_override_node" type="fake_speed_override_node"/>
+  <!-- Operation Mode -->
+  <include if="$(arg has_operation_mode_support)"
+           file="$(find prbt_hardware_support)/launch/operation_mode.launch" />
+  <node unless="$(arg has_operation_mode_support)"
+        pkg="prbt_hardware_support" name="fake_speed_override_node" type="fake_speed_override_node"/>
 </launch>

--- a/prbt_support/launch/robot.launch
+++ b/prbt_support/launch/robot.launch
@@ -70,15 +70,20 @@
   <node pkg="rosservice" type="rosservice" name="robot_init" args="call --wait /prbt/driver/init"/>
 
   <!-- Open modbus connection and required modules -->
-  <include file="$(find prbt_hardware_support)/launch/safety_interface.launch" if="$(arg iso10218_support)">
-    <arg name="safety_hw" value="$(arg safety_hw)"/>
-    <arg name="read_api_spec_file" value="$(arg read_api_spec_file)" />
-    <arg name="write_api_spec_file" value="$(arg write_api_spec_file)" />
-    <arg name="modbus_server_ip" value="$(arg modbus_server_ip)" />
-    <arg name="has_braketest_support" value="$(arg has_braketest_support)"/>
-    <arg name="has_operation_mode_support" value="$(arg has_operation_mode_support)"/>
-    <arg name="visual_status_indicator" value="$(arg visual_status_indicator)"/>
-  </include>
+  <group if="$(arg iso10218_support)">
+    <include file="$(find prbt_hardware_support)/launch/safety_interface.launch">
+      <arg name="safety_hw" value="$(arg safety_hw)"/>
+      <arg name="read_api_spec_file" value="$(arg read_api_spec_file)" />
+      <arg name="write_api_spec_file" value="$(arg write_api_spec_file)" />
+      <arg name="modbus_server_ip" value="$(arg modbus_server_ip)" />
+      <arg name="has_braketest_support" value="$(arg has_braketest_support)"/>
+      <arg name="has_operation_mode_support" value="$(arg has_operation_mode_support)"/>
+    </include>
+    <!-- Status Indicator -->
+    <node pkg="pilz_status_indicator_rqt" name="pilz_status_indicator_rqt" type="pilz_status_indicator_rqt"
+          if="$(arg visual_status_indicator)" />
+  </group>
+
   <!-- If no safety controller is connected, further initialization steps are required -->
   <group unless="$(arg iso10218_support)">
     <node name="robot_recover" pkg="rosservice" type="rosservice"


### PR DESCRIPTION
Replacement for #360, which introduced a circular dependency between `prbt_hardware_support` and `pilz_status_indicator_rqt`.

Should also fix failures on ROS buildfarm mentioned in #360.