### PR TITLE
Enhance safety interface launchfiles

### DIFF
--- a/prbt_hardware_support/launch/brake_test.launch
+++ b/prbt_hardware_support/launch/brake_test.launch
@@ -16,11 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <launch>
-  <arg name="write_api_spec_file" default="$(find prbt_hardware_support)/config/modbus_write_api_spec_pss4000.yaml" />
-
-  <include file="$(find prbt_hardware_support)/launch/modbus_adapter_brake_test_node.launch">
-    <arg name="write_api_spec_file" value="$(arg write_api_spec_file)" />
-  </include>
+  <include file="$(find prbt_hardware_support)/launch/modbus_adapter_brake_test_node.launch" />
   <include file="$(find prbt_hardware_support)/launch/canopen_braketest_adapter_node.launch" />
   <include file="$(find prbt_hardware_support)/launch/brake_test_executor_node.launch" />
 

--- a/prbt_hardware_support/launch/modbus_adapter_brake_test_node.launch
+++ b/prbt_hardware_support/launch/modbus_adapter_brake_test_node.launch
@@ -16,7 +16,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <launch>
-  <arg name="write_api_spec_file" default="$(find prbt_hardware_support)/config/modbus_write_api_spec_pss4000.yaml" />
-  <rosparam ns="/prbt/write_api_spec" command="load" file="$(arg write_api_spec_file)" />
   <node required="true" ns="prbt" pkg="prbt_hardware_support" type="modbus_adapter_brake_test_node" name="modbus_adapter_brake_test_node" output="screen"/>
 </launch>

--- a/prbt_hardware_support/launch/modbus_client.launch
+++ b/prbt_hardware_support/launch/modbus_client.launch
@@ -28,8 +28,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- define the connected safety hardware -->
 <arg name="safety_hw" default="pss4000" />
+<arg name="read_api_spec_file" default="$(find prbt_hardware_support)/config/modbus_read_api_spec_$(arg safety_hw).yaml" />
 
-<rosparam ns="/prbt/read_api_spec" command="load" file="$(find prbt_hardware_support)/config/modbus_read_api_spec_$(arg safety_hw).yaml" />
+<rosparam ns="/prbt/read_api_spec" command="load" file="$(arg read_api_spec_file)" />
   <arg name="has_register_range_parameters"
        value="$(eval arg('index_of_first_register_to_read')!='' and arg('num_registers_to_read')!='')" />
 

--- a/prbt_hardware_support/launch/modbus_client.launch
+++ b/prbt_hardware_support/launch/modbus_client.launch
@@ -17,20 +17,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <launch>
 
-<!-- default modbus server ip (PSS400) and port number -->
-<arg name="modbus_server_ip" default="192.168.0.10" />
-<arg name="modbus_server_port" default="502" />
+  <!-- default modbus server ip (PSS400) and port number -->
+  <arg name="modbus_server_ip" default="192.168.0.10" />
+  <arg name="modbus_server_port" default="502" />
 
-<!-- the register range for reading is determined automatically from the api spec,
-      however this can be overruled by specifying the following arguments -->
-<arg name="index_of_first_register_to_read" default="" />
-<arg name="num_registers_to_read" default="" />
+  <!-- the register range for reading is determined automatically from the api spec,
+       however this can be overruled by specifying the following arguments -->
+  <arg name="index_of_first_register_to_read" default="" />
+  <arg name="num_registers_to_read" default="" />
 
-<!-- define the connected safety hardware -->
-<arg name="safety_hw" default="pss4000" />
-<arg name="read_api_spec_file" default="$(find prbt_hardware_support)/config/modbus_read_api_spec_$(arg safety_hw).yaml" />
+  <!-- define the connected safety hardware -->
+  <arg name="safety_hw" default="pss4000" />
+  <arg name="read_api_spec_file" default="$(find prbt_hardware_support)/config/modbus_read_api_spec_$(arg safety_hw).yaml" />
 
-<rosparam ns="/prbt/read_api_spec" command="load" file="$(arg read_api_spec_file)" />
+  <rosparam ns="/prbt/read_api_spec" command="load" file="$(arg read_api_spec_file)" />
   <arg name="has_register_range_parameters"
        value="$(eval arg('index_of_first_register_to_read')!='' and arg('num_registers_to_read')!='')" />
 

--- a/prbt_hardware_support/launch/safety_interface.launch
+++ b/prbt_hardware_support/launch/safety_interface.launch
@@ -35,6 +35,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <!-- Modbus connection -->
   <include file="$(find prbt_hardware_support)/launch/modbus_client.launch">
     <arg name="modbus_server_ip" value="$(arg modbus_server_ip)" />
+    <arg name="read_api_spec_file" value="$(arg read_api_spec_file)" />
+    <arg name="safety_hw" value="$(arg safety_hw)" />
   </include>
   <!-- Run permitted -->
   <include file="$(find prbt_hardware_support)/launch/modbus_adapter_run_permitted_node.launch" />

--- a/prbt_hardware_support/launch/safety_interface.launch
+++ b/prbt_hardware_support/launch/safety_interface.launch
@@ -41,9 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <include file="$(find prbt_hardware_support)/launch/stop1_executor_node.launch" />
 
   <!-- Brake test -->
-  <include if="$(arg has_braketest_support)" file="$(find prbt_hardware_support)/launch/brake_test.launch">
-    <arg name="write_api_spec_file" value="$(arg write_api_spec_file)" />
-  </include>
+  <include if="$(arg has_braketest_support)" file="$(find prbt_hardware_support)/launch/brake_test.launch" />
 
   <!-- Operation Mode -->
   <include if="$(arg has_operation_mode_support)"


### PR DESCRIPTION
* brake-test launch files are only used via `safety_interface.launch`, so loading the api-spec is redundant.
* Add argument `read_api_spec_file` to `modbus_client.launch`, the default is unchanged.
* Fix indentation in `modbus_client.launch`