### PR TITLE
Set clang-format ConstructorInitializerAllOnOneLineOrOnePerLine: false

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,7 +16,7 @@ BreakBeforeTernaryOperators: false
 BreakConstructorInitializersBeforeComma: true
 BinPackParameters: true
 ColumnLimit: 120
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
 DerivePointerBinding: false
 PointerBindsToType: true
 ExperimentalAutoDetectBinPacking: false

--- a/pilz_testutils/include/pilz_testutils/service_client_mock.h
+++ b/pilz_testutils/include/pilz_testutils/service_client_mock.h
@@ -39,7 +39,9 @@ public:
 
   ServiceClientMock(const std::string& name, const CallFunction& call_callback,
                     const LogicalOperatorFunction& negation_operator_callback)
-    : name_(name), call_callback_(call_callback), negation_operator_callback_(negation_operator_callback)
+    : name_(name)
+    , call_callback_(call_callback)
+    , negation_operator_callback_(negation_operator_callback)
   {
   }
 

--- a/pilz_utils/include/pilz_utils/get_param.h
+++ b/pilz_utils/include/pilz_utils/get_param.h
@@ -34,7 +34,8 @@ public:
   GetParamException(const std::string& msg);
 };
 
-inline GetParamException::GetParamException(const std::string& msg) : std::runtime_error(msg)
+inline GetParamException::GetParamException(const std::string& msg)
+  : std::runtime_error(msg)
 {
 }
 

--- a/prbt_hardware_support/include/prbt_hardware_support/brake_test_executor.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/brake_test_executor.h
@@ -39,7 +39,8 @@ using BrakeTestResultFunc = std::function<bool(const bool)>;
 class BrakeTestExecutorException : public std::runtime_error
 {
 public:
-  BrakeTestExecutorException(const std::string& what_arg) : std::runtime_error(what_arg)
+  BrakeTestExecutorException(const std::string& what_arg)
+    : std::runtime_error(what_arg)
   {
   }
 };

--- a/prbt_hardware_support/include/prbt_hardware_support/brake_test_utils_exception.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/brake_test_utils_exception.h
@@ -28,7 +28,8 @@ namespace prbt_hardware_support
 class BrakeTestUtilsException : public std::runtime_error
 {
 public:
-  BrakeTestUtilsException(const std::string& what_arg) : std::runtime_error(what_arg)
+  BrakeTestUtilsException(const std::string& what_arg)
+    : std::runtime_error(what_arg)
   {
   }
 };
@@ -39,7 +40,8 @@ public:
 class GetCurrentJointStatesException : public BrakeTestUtilsException
 {
 public:
-  GetCurrentJointStatesException(const std::string& what_arg) : BrakeTestUtilsException(what_arg)
+  GetCurrentJointStatesException(const std::string& what_arg)
+    : BrakeTestUtilsException(what_arg)
   {
   }
 };

--- a/prbt_hardware_support/include/prbt_hardware_support/modbus_adapter_brake_test_exception.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/modbus_adapter_brake_test_exception.h
@@ -28,7 +28,8 @@ namespace prbt_hardware_support
 class ModbusAdapterBrakeTestException : public std::runtime_error
 {
 public:
-  ModbusAdapterBrakeTestException(const std::string& what_arg) : std::runtime_error(what_arg)
+  ModbusAdapterBrakeTestException(const std::string& what_arg)
+    : std::runtime_error(what_arg)
   {
   }
 };

--- a/prbt_hardware_support/include/prbt_hardware_support/modbus_api_spec.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/modbus_api_spec.h
@@ -47,7 +47,8 @@ static const std::string BRAKETEST_RESULT{ "BRAKETEST_RESULT" };
 class ModbusApiSpecException : public std::runtime_error
 {
 public:
-  ModbusApiSpecException(const std::string& what_arg) : std::runtime_error(what_arg)
+  ModbusApiSpecException(const std::string& what_arg)
+    : std::runtime_error(what_arg)
   {
   }
 };
@@ -83,7 +84,8 @@ public:
    *
    * @param nh NodeHandle to read the parameters from
    */
-  ModbusApiSpecTemplated(T& nh) : ModbusApiSpecTemplated(nh, READ_API_SPEC_PARAM_NAME)
+  ModbusApiSpecTemplated(T& nh)
+    : ModbusApiSpecTemplated(nh, READ_API_SPEC_PARAM_NAME)
   {
   }
 

--- a/prbt_hardware_support/include/prbt_hardware_support/modbus_msg_brake_test_wrapper_exception.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/modbus_msg_brake_test_wrapper_exception.h
@@ -30,7 +30,8 @@ namespace prbt_hardware_support
 class ModbusMsgBrakeTestWrapperException : public ModbusMsgWrapperException
 {
 public:
-  ModbusMsgBrakeTestWrapperException(const std::string& what_arg) : ModbusMsgWrapperException(what_arg)
+  ModbusMsgBrakeTestWrapperException(const std::string& what_arg)
+    : ModbusMsgWrapperException(what_arg)
   {
   }
 };

--- a/prbt_hardware_support/include/prbt_hardware_support/modbus_msg_operation_mode_wrapper_exception.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/modbus_msg_operation_mode_wrapper_exception.h
@@ -31,7 +31,8 @@ namespace prbt_hardware_support
 class ModbusMsgOperationModeWrapperException : public ModbusMsgWrapperException
 {
 public:
-  ModbusMsgOperationModeWrapperException(const std::string& what_arg) : ModbusMsgWrapperException(what_arg)
+  ModbusMsgOperationModeWrapperException(const std::string& what_arg)
+    : ModbusMsgWrapperException(what_arg)
   {
   }
 };

--- a/prbt_hardware_support/include/prbt_hardware_support/modbus_msg_run_permitted_wrapper_exception.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/modbus_msg_run_permitted_wrapper_exception.h
@@ -33,7 +33,8 @@ namespace prbt_hardware_support
 class ModbusMsgRunPermittedStatusMissing : public ModbusMsgWrapperException
 {
 public:
-  ModbusMsgRunPermittedStatusMissing(const std::string& what_arg) : ModbusMsgWrapperException(what_arg)
+  ModbusMsgRunPermittedStatusMissing(const std::string& what_arg)
+    : ModbusMsgWrapperException(what_arg)
   {
   }
 };

--- a/prbt_hardware_support/include/prbt_hardware_support/modbus_msg_wrapper.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/modbus_msg_wrapper.h
@@ -97,7 +97,8 @@ private:
 
 inline ModbusMsgWrapper::ModbusMsgWrapper(const ModbusMsgInStampedConstPtr& modbus_msg_raw,
                                           const ModbusApiSpec& api_spec)
-  : api_spec_(api_spec), msg_(modbus_msg_raw)
+  : api_spec_(api_spec)
+  , msg_(modbus_msg_raw)
 {
 }
 

--- a/prbt_hardware_support/include/prbt_hardware_support/modbus_msg_wrapper_exception.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/modbus_msg_wrapper_exception.h
@@ -31,7 +31,8 @@ namespace prbt_hardware_support
 class ModbusMsgWrapperException : public std::runtime_error
 {
 public:
-  ModbusMsgWrapperException(const std::string& what_arg) : std::runtime_error(what_arg)
+  ModbusMsgWrapperException(const std::string& what_arg)
+    : std::runtime_error(what_arg)
   {
   }
 };

--- a/prbt_hardware_support/include/prbt_hardware_support/pilz_modbus_client_exception.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/pilz_modbus_client_exception.h
@@ -28,7 +28,8 @@ namespace prbt_hardware_support
 class PilzModbusClientException : public std::runtime_error
 {
 public:
-  PilzModbusClientException(const std::string& what_arg) : std::runtime_error(what_arg)
+  PilzModbusClientException(const std::string& what_arg)
+    : std::runtime_error(what_arg)
   {
   }
 };

--- a/prbt_hardware_support/include/prbt_hardware_support/pilz_modbus_exceptions.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/pilz_modbus_exceptions.h
@@ -28,7 +28,8 @@
 class ModbusExceptionDisconnect : public std::runtime_error
 {
 public:
-  ModbusExceptionDisconnect(const std::string& what_arg) : std::runtime_error(what_arg){};
+  ModbusExceptionDisconnect(const std::string& what_arg)
+    : std::runtime_error(what_arg){};
 };
 
 #endif  // PILZ_MODBUS_EXCEPTIONS_H

--- a/prbt_hardware_support/include/prbt_hardware_support/run_permitted_state_machine.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/run_permitted_state_machine.h
@@ -61,7 +61,8 @@ class AsyncRunPermittedTask
 {
 public:
   AsyncRunPermittedTask(const TServiceCallFunc& operation, const std::function<void()>& finished_handler)
-    : operation_(operation), finished_handler_(finished_handler)
+    : operation_(operation)
+    , finished_handler_(finished_handler)
   {
   }
 
@@ -117,7 +118,10 @@ public:
    */
   RunPermittedStateMachine_(const TServiceCallFunc& recover_operation, const TServiceCallFunc& halt_operation,
                             const TServiceCallFunc& hold_operation, const TServiceCallFunc& unhold_operation)
-    : recover_op_(recover_operation), halt_op_(halt_operation), hold_op_(hold_operation), unhold_op_(unhold_operation)
+    : recover_op_(recover_operation)
+    , halt_op_(halt_operation)
+    , hold_op_(hold_operation)
+    , unhold_op_(unhold_operation)
   {
   }
 
@@ -220,7 +224,8 @@ public:
    */
   struct run_permitted_updated
   {
-    run_permitted_updated(const bool run_permitted) : run_permitted_(run_permitted)
+    run_permitted_updated(const bool run_permitted)
+      : run_permitted_(run_permitted)
     {
     }
 

--- a/prbt_hardware_support/src/adapter_operation_mode.cpp
+++ b/prbt_hardware_support/src/adapter_operation_mode.cpp
@@ -24,7 +24,8 @@ static const std::string SERVICE_NAME_GET_OPERATION_MODE = "/prbt/get_operation_
 
 static constexpr int DEFAULT_QUEUE_SIZE{ 10 };
 
-AdapterOperationMode::AdapterOperationMode(ros::NodeHandle& nh) : nh_(nh)
+AdapterOperationMode::AdapterOperationMode(ros::NodeHandle& nh)
+  : nh_(nh)
 {
   op_mode_.time_stamp = ros::Time::now();
   op_mode_.value = OperationModes::UNKNOWN;

--- a/prbt_hardware_support/src/canopen_braketest_adapter.cpp
+++ b/prbt_hardware_support/src/canopen_braketest_adapter.cpp
@@ -43,7 +43,8 @@ static const std::string GET_BRAKETEST_DURATION_OBJECT{ "2060sub1" };
 static const std::string SET_START_BRAKETEST_OBJECT{ "2060sub2" };
 static const std::string GET_BRAKETEST_STATUS_OBJECT{ "2060sub3" };
 
-CANOpenBrakeTestAdapter::CANOpenBrakeTestAdapter(ros::NodeHandle& nh) : nh_(nh)
+CANOpenBrakeTestAdapter::CANOpenBrakeTestAdapter(ros::NodeHandle& nh)
+  : nh_(nh)
 {
   brake_test_srv_ = nh_.advertiseService(nh_.getNamespace() + TRIGGER_BRAKETEST_SERVICE_NAME,
                                          &CANOpenBrakeTestAdapter::triggerBrakeTests, this);

--- a/prbt_hardware_support/src/canopen_braketest_adapter_exception.cpp
+++ b/prbt_hardware_support/src/canopen_braketest_adapter_exception.cpp
@@ -21,7 +21,8 @@ namespace prbt_hardware_support
 {
 CANOpenBrakeTestAdapterException::CANOpenBrakeTestAdapterException(const std::string& what_arg,
                                                                    const int8_t error_value)
-  : std::runtime_error(what_arg), error_value_(error_value)
+  : std::runtime_error(what_arg)
+  , error_value_(error_value)
 {
 }
 

--- a/prbt_hardware_support/src/modbus_adapter_run_permitted.cpp
+++ b/prbt_hardware_support/src/modbus_adapter_run_permitted.cpp
@@ -25,7 +25,8 @@ namespace prbt_hardware_support
 {
 ModbusAdapterRunPermitted::ModbusAdapterRunPermitted(UpdateRunPermittedFunc&& update_run_permitted_func,
                                                      const ModbusApiSpec& api_spec)
-  : api_spec_(api_spec), update_run_permitted_(std::move(update_run_permitted_func))
+  : api_spec_(api_spec)
+  , update_run_permitted_(std::move(update_run_permitted_func))
 {
 }
 

--- a/prbt_hardware_support/src/modbus_msg_in_builder.cpp
+++ b/prbt_hardware_support/src/modbus_msg_in_builder.cpp
@@ -23,7 +23,8 @@
 
 namespace prbt_hardware_support
 {
-ModbusMsgInBuilder::ModbusMsgInBuilder(const ModbusApiSpec& api_spec) : api_spec_(api_spec)
+ModbusMsgInBuilder::ModbusMsgInBuilder(const ModbusApiSpec& api_spec)
+  : api_spec_(api_spec)
 {
 }
 

--- a/prbt_hardware_support/src/operation_mode_setup_executor.cpp
+++ b/prbt_hardware_support/src/operation_mode_setup_executor.cpp
@@ -21,7 +21,9 @@ namespace prbt_hardware_support
 {
 OperationModeSetupExecutor::OperationModeSetupExecutor(const double& speed_limit_t1, const double& speed_limit_auto,
                                                        const SetSpeedLimitFunc& set_speed_limit_func)
-  : speed_limit_t1_(speed_limit_t1), speed_limit_auto_(speed_limit_auto), set_speed_limit_func_(set_speed_limit_func)
+  : speed_limit_t1_(speed_limit_t1)
+  , speed_limit_auto_(speed_limit_auto)
+  , set_speed_limit_func_(set_speed_limit_func)
 {
 }
 

--- a/prbt_hardware_support/src/speed_observer.cpp
+++ b/prbt_hardware_support/src/speed_observer.cpp
@@ -31,7 +31,9 @@ static const std::string RUN_PERMITTED_SERVICE{ "run_permitted" };
 
 SpeedObserver::SpeedObserver(ros::NodeHandle& nh, std::string& reference_frame,
                              std::vector<std::string>& frames_to_observe)
-  : nh_(nh), reference_frame_(reference_frame), frames_to_observe_(frames_to_observe)
+  : nh_(nh)
+  , reference_frame_(reference_frame)
+  , frames_to_observe_(frames_to_observe)
 {
   frame_speeds_pub_ = nh.advertise<FrameSpeeds>(FRAME_SPEEDS_TOPIC_NAME, DEFAULT_QUEUE_SIZE);
   pilz_utils::waitForService(RUN_PERMITTED_SERVICE);

--- a/prbt_hardware_support/test/unit_tests/unittest_pilz_modbus_client.cpp
+++ b/prbt_hardware_support/test/unit_tests/unittest_pilz_modbus_client.cpp
@@ -78,7 +78,8 @@ private:
   std::thread client_thread_;
 };
 
-PilzModbusClientExecutor::PilzModbusClientExecutor(PilzModbusClient* client) : client_(client)
+PilzModbusClientExecutor::PilzModbusClientExecutor(PilzModbusClient* client)
+  : client_(client)
 {
 }
 
@@ -373,7 +374,8 @@ TEST_F(PilzModbusClientTests, testSettingOfTimeOut)
 class HoldingRegisterIncreaser
 {
 public:
-  HoldingRegisterIncreaser(unsigned int register_index = 0u) : register_index_(register_index)
+  HoldingRegisterIncreaser(unsigned int register_index = 0u)
+    : register_index_(register_index)
   {
   }
 

--- a/prbt_hardware_support/test/unit_tests/unittest_update_filter.cpp
+++ b/prbt_hardware_support/test/unit_tests/unittest_update_filter.cpp
@@ -50,7 +50,8 @@ public:
 class TestPublisher : public ros::Publisher
 {
 public:
-  TestPublisher(const Publisher& rhs) : ros::Publisher::Publisher(rhs)
+  TestPublisher(const Publisher& rhs)
+    : ros::Publisher::Publisher(rhs)
   {
   }
 

--- a/prbt_support/src/system_info.cpp
+++ b/prbt_support/src/system_info.cpp
@@ -37,7 +37,8 @@ static const std::string GET_FIRMWARE_VERSION_OBJECT{ "100A" };
 // This is currently under investigation. See https://github.com/PilzDE/pilz_robots/issues/299.
 static constexpr std::size_t FIRMWARE_STRING_LENGTH{ 40 };
 
-SystemInfo::SystemInfo(ros::NodeHandle& nh) : joint_names_(getNodeNames(nh))
+SystemInfo::SystemInfo(ros::NodeHandle& nh)
+  : joint_names_(getNodeNames(nh))
 {
   // Wait till CAN is up and running.
   // Reason: If the first CAN service call happens before

--- a/prbt_support/src/system_info_exception.cpp
+++ b/prbt_support/src/system_info_exception.cpp
@@ -19,7 +19,8 @@
 
 namespace prbt_support
 {
-SystemInfoException::SystemInfoException(const std::string& what_arg) : std::runtime_error(what_arg)
+SystemInfoException::SystemInfoException(const std::string& what_arg)
+  : std::runtime_error(what_arg)
 {
 }
 


### PR DESCRIPTION
Update:
Closed and opened https://github.com/PilzDE/psen_scan/pull/20

===================================================

This Draft PR serves as a basis for a discussion would hopefully lead towards an unification of the
styles of 
- https://github.com/PilzDE/psen_scan
- https://github.com/PilzDE/pilz_robots

Context:

This repo uses
`ConstructorInitializerAllOnOneLineOrOnePerLine: true`

while  [https://github.com/PilzDE/psen_scan](https://github.com/PilzDE/psen_scan/blob/07b878aca5abde3a64f4c9ef2249a605107b8449/.clang-format#L21)
uses 
`ConstructorInitializerAllOnOneLineOrOnePerLine: false`

The official ROSStyleGuide links https://github.com/davetcoleman/roscpp_code_format/blob/bfa4ea78b4ac856da07458c8824bf5eb327ea693/.clang-format#L19 which states
`ConstructorInitializerAllOnOneLineOrOnePerLine: true`
which is the same as the Google Style (check with `clang-format -style=google -dump-config | grep ConstructorInitializerAllOnOneLineOrOnePerLine:`).

Thus this PR would be in opposition to this Styles.
See the diff for an impression what this changes.

Tbh I don't mind that much but maybe some others have a preference.

So please anyone having a opinion on this :+1: or :-1: and comment if you like.

If this PR is rejected I would open the opposing PR on https://github.com/PilzDE/psen_scan.