### PR TITLE
Improving error response in case of IP adress failures.

### DIFF
--- a/prbt_hardware_support/include/prbt_hardware_support/libmodbus_client.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/libmodbus_client.h
@@ -72,7 +72,7 @@ private:
  * @return true if the connection to the server succeeded
  * @return false if the connection to the server failed
  */
-bool checkIPConnection(const char* ip, const unsigned int port, double timeout, const unsigned int n_retries);
+bool checkIPConnection(const char* ip, const unsigned int port);
 
 }  // namespace prbt_hardware_support
 

--- a/prbt_hardware_support/include/prbt_hardware_support/libmodbus_client.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/libmodbus_client.h
@@ -60,6 +60,7 @@ public:
 
 private:
   modbus_t* modbus_connection_{ nullptr };
+  bool checkIPConnection(const char* ip, unsigned int port, unsigned int timeout, unsigned int retries);
 };
 
 }  // namespace prbt_hardware_support

--- a/prbt_hardware_support/include/prbt_hardware_support/libmodbus_client.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/libmodbus_client.h
@@ -60,7 +60,7 @@ public:
 
 private:
   modbus_t* modbus_connection_{ nullptr };
-  bool checkIPConnection(const char* ip, unsigned int port, unsigned int timeout, unsigned int retries);
+  bool checkIPConnection(const char* ip, unsigned int port, unsigned int timeout, unsigned int retries) const;
 };
 
 }  // namespace prbt_hardware_support

--- a/prbt_hardware_support/include/prbt_hardware_support/libmodbus_client.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/libmodbus_client.h
@@ -63,15 +63,15 @@ private:
 };
 
 /**
-   * @brief Test the ip connection by connecting to the modbus server
-   *
-   * @param ip of the modbus server
-   * @param port of the modbus server
-   * @param timeout of the modbus connection attempt
-   * @param retries of the connection attempt lasting as long as defined in timout 
-   * @return true if the connection to the server succeeded
-   * @return false if the connection to the server failed
-   */
+ * @brief Test the ip connection by connecting to the modbus server
+ *
+ * @param ip of the modbus server
+ * @param port of the modbus server
+ * @param timeout of the modbus connection attempt
+ * @param retries of the connection attempt lasting as long as defined in timout
+ * @return true if the connection to the server succeeded
+ * @return false if the connection to the server failed
+ */
 bool checkIPConnection(const char* ip, unsigned int port, unsigned int timeout, unsigned int retries);
 
 }  // namespace prbt_hardware_support

--- a/prbt_hardware_support/include/prbt_hardware_support/libmodbus_client.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/libmodbus_client.h
@@ -67,8 +67,6 @@ private:
  *
  * @param ip of the modbus server
  * @param port of the modbus server
- * @param timeout of the modbus connection attempt in seconds
- * @param retries of the connection attempt lasting as long as defined in timout
  * @return true if the connection to the server succeeded
  * @return false if the connection to the server failed
  */

--- a/prbt_hardware_support/include/prbt_hardware_support/libmodbus_client.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/libmodbus_client.h
@@ -72,7 +72,7 @@ private:
  * @return true if the connection to the server succeeded
  * @return false if the connection to the server failed
  */
-bool checkIPConnection(const char* ip, unsigned int port, double timeout, unsigned int retries);
+bool checkIPConnection(const char* ip, unsigned int port, double timeout, const unsigned int n_retries);
 
 }  // namespace prbt_hardware_support
 

--- a/prbt_hardware_support/include/prbt_hardware_support/libmodbus_client.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/libmodbus_client.h
@@ -60,8 +60,19 @@ public:
 
 private:
   modbus_t* modbus_connection_{ nullptr };
-  bool checkIPConnection(const char* ip, unsigned int port, unsigned int timeout, unsigned int retries) const;
 };
+
+/**
+   * @brief Test the ip connection by connecting to the modbus server
+   *
+   * @param ip of the modbus server
+   * @param port of the modbus server
+   * @param timeout of the modbus connection attempt
+   * @param retries of the connection attempt lasting as long as defined in timout 
+   * @return true if the connection to the server succeeded
+   * @return false if the connection to the server failed
+   */
+bool checkIPConnection(const char* ip, unsigned int port, unsigned int timeout, unsigned int retries);
 
 }  // namespace prbt_hardware_support
 

--- a/prbt_hardware_support/include/prbt_hardware_support/libmodbus_client.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/libmodbus_client.h
@@ -67,12 +67,12 @@ private:
  *
  * @param ip of the modbus server
  * @param port of the modbus server
- * @param timeout of the modbus connection attempt
+ * @param timeout of the modbus connection attempt in seconds
  * @param retries of the connection attempt lasting as long as defined in timout
  * @return true if the connection to the server succeeded
  * @return false if the connection to the server failed
  */
-bool checkIPConnection(const char* ip, unsigned int port, unsigned int timeout, unsigned int retries);
+bool checkIPConnection(const char* ip, unsigned int port, double timeout, unsigned int retries);
 
 }  // namespace prbt_hardware_support
 

--- a/prbt_hardware_support/include/prbt_hardware_support/libmodbus_client.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/libmodbus_client.h
@@ -72,7 +72,7 @@ private:
  * @return true if the connection to the server succeeded
  * @return false if the connection to the server failed
  */
-bool checkIPConnection(const char* ip, unsigned int port, double timeout, const unsigned int n_retries);
+bool checkIPConnection(const char* ip, const unsigned int port, double timeout, const unsigned int n_retries);
 
 }  // namespace prbt_hardware_support
 

--- a/prbt_hardware_support/src/libmodbus_client.cpp
+++ b/prbt_hardware_support/src/libmodbus_client.cpp
@@ -166,8 +166,8 @@ bool checkIPConnection(const char* ip, const unsigned int port)
   fd_set writeset;
   struct timeval tv;
 
-  tv.tv_sec = 0;
-  tv.tv_usec = 100000;  // timout is 100ms
+  tv.tv_sec = 1;
+  tv.tv_usec = 0;  // timout is 100ms
 
   sockfd = socket(AF_INET, SOCK_STREAM, 0);  // Create socket for connection testing purpose
   bzero((char*)&serv_addr, sizeof(serv_addr));

--- a/prbt_hardware_support/src/libmodbus_client.cpp
+++ b/prbt_hardware_support/src/libmodbus_client.cpp
@@ -126,7 +126,7 @@ RegCont LibModbusClient::writeReadHoldingRegister(const int write_addr, const Re
   return read_reg;
 }
 
-bool LibModbusClient::checkIPConnection(const char* ip, unsigned int port, unsigned int timeout, unsigned int retries)
+bool LibModbusClient::checkIPConnection(const char* ip, unsigned int port, unsigned int timeout, unsigned int retries) const
 {
   long   result;
   int    sockfd;

--- a/prbt_hardware_support/src/libmodbus_client.cpp
+++ b/prbt_hardware_support/src/libmodbus_client.cpp
@@ -47,7 +47,8 @@ bool LibModbusClient::init(const char* ip, unsigned int port)
   // timeout for modbus_connect(). Thank you!
   if (!checkIPConnection(ip, port))
   {
-    ROS_DEBUG_STREAM("Precheck for connection to " << ip << ":" << port << " failed.");
+    ROS_ERROR_STREAM("Precheck for connection to " << ip << ":" << port << " failed. " << modbus_strerror(errno)
+                                                   << ".");
     return false;
   }
 
@@ -57,7 +58,8 @@ bool LibModbusClient::init(const char* ip, unsigned int port)
   {
     // LCOV_EXCL_START the following lines are hard to cover since the above checkIPConnection should prevent
     // exactly this situation
-    ROS_ERROR_STREAM_NAMED("LibModbusClient", "Could not establish modbus connection." << modbus_strerror(errno));
+    ROS_ERROR_STREAM_NAMED("LibModbusClient",
+                           "Could not establish modbus connection. " << modbus_strerror(errno) << ".");
     modbus_free(modbus_connection_);
     modbus_connection_ = nullptr;
     return false;

--- a/prbt_hardware_support/src/libmodbus_client.cpp
+++ b/prbt_hardware_support/src/libmodbus_client.cpp
@@ -22,7 +22,7 @@
 #include <errno.h>
 #include <limits>
 #include <stdexcept>
-#include <arpa/inet.h> 
+#include <arpa/inet.h>
 #include <fcntl.h>
 #include <prbt_hardware_support/libmodbus_client.h>
 #include <prbt_hardware_support/pilz_modbus_exceptions.h>
@@ -36,9 +36,8 @@ LibModbusClient::~LibModbusClient()
 
 bool LibModbusClient::init(const char* ip, unsigned int port)
 {
- 
   modbus_connection_ = modbus_new_tcp(ip, static_cast<int>(port));
- 
+
   if (modbus_connect(modbus_connection_) == -1)
   {
     ROS_ERROR_STREAM_NAMED("LibModbusClient", "Could not establish modbus connection." << modbus_strerror(errno));
@@ -46,7 +45,7 @@ bool LibModbusClient::init(const char* ip, unsigned int port)
     modbus_connection_ = nullptr;
     return false;
   }
-  
+
   return true;
 }
 
@@ -126,36 +125,37 @@ RegCont LibModbusClient::writeReadHoldingRegister(const int write_addr, const Re
   return read_reg;
 }
 
-bool LibModbusClient::checkIPConnection(const char* ip, unsigned int port, unsigned int timeout, unsigned int retries) const
+bool LibModbusClient::checkIPConnection(const char* ip, unsigned int port, unsigned int timeout,
+                                        unsigned int retries) const
 {
-  long   result;
-  int    sockfd;
+  long result;
+  int sockfd;
   struct sockaddr_in serv_addr;
-  
-  sockfd = socket(AF_INET, SOCK_STREAM, 0);      // Create socket for connection testing purpose
-  bzero((char *) &serv_addr, sizeof(serv_addr)); 
-  serv_addr.sin_family = AF_INET;                   
+
+  sockfd = socket(AF_INET, SOCK_STREAM, 0);  // Create socket for connection testing purpose
+  bzero((char*)&serv_addr, sizeof(serv_addr));
+  serv_addr.sin_family = AF_INET;
   serv_addr.sin_port = htons((short unsigned int)port);
-  
-  result = fcntl(sockfd, F_GETFL, NULL); 
-  result |= O_NONBLOCK; 
-  fcntl(sockfd, F_SETFL, result);                   //set connection to non blocking, no timeout
-  serv_addr.sin_addr.s_addr = inet_addr(ip); 
-  
-  //try "retries" times to connect 
-  while ((connect(sockfd,(const sockaddr *) &serv_addr,sizeof(serv_addr)) < 0) && ( 0 != retries))
+
+  result = fcntl(sockfd, F_GETFL, NULL);
+  result |= O_NONBLOCK;
+  fcntl(sockfd, F_SETFL, result);  // set connection to non blocking, no timeout
+  serv_addr.sin_addr.s_addr = inet_addr(ip);
+
+  // try "retries" times to connect
+  while ((connect(sockfd, (const sockaddr*)&serv_addr, sizeof(serv_addr)) < 0) && (0 != retries))
   {
-    retries--;    
-    if (0  == retries)
+    retries--;
+    if (0 == retries)
     {
-       ROS_ERROR_STREAM_NAMED("LibModbusClient","Could not establish modbus connection. Cable connected?");
-       return false;
+      ROS_ERROR_STREAM_NAMED("LibModbusClient", "Could not establish modbus connection. Cable connected?");
+      return false;
     }
-    usleep(timeout); // wait "timout" usec
+    usleep(timeout);  // wait "timout" usec
   }
-  ::close(sockfd); 
-  sleep(1);          // wait one second to grant a free port
-  
+  ::close(sockfd);
+  sleep(1);  // wait one second to grant a free port
+
   return true;
 }
 

--- a/prbt_hardware_support/src/libmodbus_client.cpp
+++ b/prbt_hardware_support/src/libmodbus_client.cpp
@@ -38,7 +38,11 @@ LibModbusClient::~LibModbusClient()
 
 bool LibModbusClient::init(const char* ip, unsigned int port)
 {
-  checkIPConnection(ip, port, 1, 10);
+  if(!checkIPConnection(ip, port, 1, 10))
+  {
+    ROS_ERROR_STREAM("Precheck for connection to " << ip << ":" << port << " failed.");
+    return false;
+  }
 
   modbus_connection_ = modbus_new_tcp(ip, static_cast<int>(port));
 

--- a/prbt_hardware_support/src/libmodbus_client.cpp
+++ b/prbt_hardware_support/src/libmodbus_client.cpp
@@ -125,8 +125,18 @@ RegCont LibModbusClient::writeReadHoldingRegister(const int write_addr, const Re
   return read_reg;
 }
 
-bool LibModbusClient::checkIPConnection(const char* ip, unsigned int port, unsigned int timeout,
-                                        unsigned int retries) const
+void LibModbusClient::close()
+{
+  if (modbus_connection_)
+  {
+    modbus_close(modbus_connection_);
+    modbus_free(modbus_connection_);
+    modbus_connection_ = nullptr;
+  }
+}
+
+bool checkIPConnection(const char* ip, unsigned int port, unsigned int timeout,
+                                        unsigned int retries) 
 {
   long result;
   int sockfd;
@@ -157,16 +167,6 @@ bool LibModbusClient::checkIPConnection(const char* ip, unsigned int port, unsig
   sleep(1);  // wait one second to grant a free port
 
   return true;
-}
-
-void LibModbusClient::close()
-{
-  if (modbus_connection_)
-  {
-    modbus_close(modbus_connection_);
-    modbus_free(modbus_connection_);
-    modbus_connection_ = nullptr;
-  }
 }
 
 }  // namespace prbt_hardware_support

--- a/prbt_hardware_support/src/libmodbus_client.cpp
+++ b/prbt_hardware_support/src/libmodbus_client.cpp
@@ -38,9 +38,9 @@ LibModbusClient::~LibModbusClient()
 
 bool LibModbusClient::init(const char* ip, unsigned int port)
 {
-  if(!checkIPConnection(ip, port, 1, 10))
+  if (!checkIPConnection(ip, port))
   {
-    ROS_ERROR_STREAM("Precheck for connection to " << ip << ":" << port << " failed.");
+    ROS_DEBUG_STREAM("Precheck for connection to " << ip << ":" << port << " failed.");
     return false;
   }
 
@@ -143,7 +143,7 @@ void LibModbusClient::close()
   }
 }
 
-bool checkIPConnection(const char* ip, const unsigned int port, double timeout, const unsigned int n_retries)
+bool checkIPConnection(const char* ip, const unsigned int port)
 {
   long result;
   int sockfd;
@@ -159,21 +159,9 @@ bool checkIPConnection(const char* ip, const unsigned int port, double timeout, 
   fcntl(sockfd, F_SETFL, result);  // set connection to non blocking, no timeout
   serv_addr.sin_addr.s_addr = inet_addr(ip);
 
-  // try "retries" times to connect
-  unsigned int tries{ 0 };
-  while ((connect(sockfd, (const sockaddr*)&serv_addr, sizeof(serv_addr)) < 0) && (tries < n_retries))
+  if (connect(sockfd, (const sockaddr*)&serv_addr, sizeof(serv_addr)) < 0)
   {
-    tries++;
-    ROS_INFO_STREAM("Trying to connect to " << ip << ":" << port << " " << tries << "/" << n_retries);
-    if (tries == n_retries)
-    {
-      ROS_ERROR_STREAM_NAMED("LibModbusClient", "Could not establish modbus connection with: "
-                                                    << ip << ":" << port
-                                                    << ". Make sure that your cables are connected properly and that "
-                                                       "you have set the right IP Address and Port");
-      return false;
-    }
-    std::this_thread::sleep_for(std::chrono::duration<double>(timeout));
+    return false;
   }
   ::close(sockfd);
   std::this_thread::sleep_for(std::chrono::duration<double>(1));  // wait one second to grant a free port

--- a/prbt_hardware_support/src/libmodbus_client.cpp
+++ b/prbt_hardware_support/src/libmodbus_client.cpp
@@ -60,7 +60,7 @@ bool LibModbusClient::init(const char* ip, unsigned int port)
        ROS_ERROR_STREAM_NAMED("LibModbusClient","Could not establish modbus connection. Cable connected?");
        return false;
     }
-    usleep(100000); // wait 1 sec
+    usleep(100000); // wait 100 ms
   }
   ::close(sockfd); 
   sleep(1);                                  //wait one second until port is released

--- a/prbt_hardware_support/src/libmodbus_client.cpp
+++ b/prbt_hardware_support/src/libmodbus_client.cpp
@@ -36,7 +36,7 @@ LibModbusClient::~LibModbusClient()
 
 bool LibModbusClient::init(const char* ip, unsigned int port)
 {
-  long   arg;
+  long   result; // auxiliary variable
   int    sockfd;
   int    retries;
   struct sockaddr_in serv_addr;
@@ -46,9 +46,9 @@ bool LibModbusClient::init(const char* ip, unsigned int port)
   serv_addr.sin_family = AF_INET;                   
   serv_addr.sin_port = htons((short unsigned int)port);
   
-  arg = fcntl(sockfd, F_GETFL, NULL); 
-  arg |= O_NONBLOCK; 
-  fcntl(sockfd, F_SETFL, arg);                   //set connection to non blocking, no timeout
+  result = fcntl(sockfd, F_GETFL, NULL); 
+  result |= O_NONBLOCK; 
+  fcntl(sockfd, F_SETFL, result);                   //set connection to non blocking, no timeout
   serv_addr.sin_addr.s_addr = inet_addr(ip); 
   retries = 20;
   //try 20 times to connect within 100 mseconds

--- a/prbt_hardware_support/src/libmodbus_client.cpp
+++ b/prbt_hardware_support/src/libmodbus_client.cpp
@@ -170,7 +170,8 @@ bool checkIPConnection(const char* ip, const unsigned int port)
 
   FD_ZERO(&writeset);         // clear writeset all to zero
   FD_SET(sockfd, &writeset);  // set the sockfd filedescriptor to be affected in following select function
-  conresult = select(sockfd + 1, NULL, &writeset, NULL, &tv);  // wait if sockfd is ready for writing with tv timeout
+  conresult =
+      select(sockfd + 1, nullptr, &writeset, nullptr, &tv);  // wait if sockfd is ready for writing with tv timeout
   if (conresult <= 0)
   {
     /* Timeout or fail */
@@ -184,9 +185,8 @@ bool checkIPConnection(const char* ip, const unsigned int port)
     ::close(sockfd);
     std::this_thread::sleep_for(std::chrono::duration<double>(1));  // wait one second to grant a free port
     return true;
-  } 
+  }
   return false;
-  
 }
 
 }  // namespace prbt_hardware_support

--- a/prbt_hardware_support/src/libmodbus_client.cpp
+++ b/prbt_hardware_support/src/libmodbus_client.cpp
@@ -38,6 +38,13 @@ LibModbusClient::~LibModbusClient()
 
 bool LibModbusClient::init(const char* ip, unsigned int port)
 {
+  // The following check results from Ubuntu 18.04 using libmodbus 3.0.6 where a timeout cannot be set on
+  // modbus_connect.
+  // As a result trying to connect with to a wrong address could modbus_connect could get stuck for up to over 100
+  // seconds. The precheck lowers this risk by performing a quick connect to the given address.
+  //
+  // If you read this comment at a time where Ubuntu 18.04 is no longer relevant please remove this check and define a
+  // timeout for modbus_connect(). Thank you!
   if (!checkIPConnection(ip, port))
   {
     ROS_DEBUG_STREAM("Precheck for connection to " << ip << ":" << port << " failed.");

--- a/prbt_hardware_support/src/libmodbus_client.cpp
+++ b/prbt_hardware_support/src/libmodbus_client.cpp
@@ -139,7 +139,7 @@ void LibModbusClient::close()
   }
 }
 
-bool checkIPConnection(const char* ip, unsigned int port, double timeout, const unsigned int n_retries)
+bool checkIPConnection(const char* ip, const unsigned int port, double timeout, const unsigned int n_retries)
 {
   long result;
   int sockfd;

--- a/prbt_hardware_support/src/libmodbus_client.cpp
+++ b/prbt_hardware_support/src/libmodbus_client.cpp
@@ -135,8 +135,7 @@ void LibModbusClient::close()
   }
 }
 
-bool checkIPConnection(const char* ip, unsigned int port, unsigned int timeout,
-                                        unsigned int retries) 
+bool checkIPConnection(const char* ip, unsigned int port, unsigned int timeout, unsigned int retries)
 {
   long result;
   int sockfd;

--- a/prbt_hardware_support/src/libmodbus_client.cpp
+++ b/prbt_hardware_support/src/libmodbus_client.cpp
@@ -21,6 +21,8 @@
 #include <vector>
 #include <errno.h>
 #include <limits>
+#include <thread>
+#include <chrono>
 #include <stdexcept>
 #include <arpa/inet.h>
 #include <fcntl.h>
@@ -36,6 +38,8 @@ LibModbusClient::~LibModbusClient()
 
 bool LibModbusClient::init(const char* ip, unsigned int port)
 {
+  checkIPConnection(ip, port, 1, 10);
+
   modbus_connection_ = modbus_new_tcp(ip, static_cast<int>(port));
 
   if (modbus_connect(modbus_connection_) == -1)
@@ -135,7 +139,7 @@ void LibModbusClient::close()
   }
 }
 
-bool checkIPConnection(const char* ip, unsigned int port, unsigned int timeout, unsigned int retries)
+bool checkIPConnection(const char* ip, unsigned int port, double timeout, unsigned int retries)
 {
   long result;
   int sockfd;
@@ -160,10 +164,10 @@ bool checkIPConnection(const char* ip, unsigned int port, unsigned int timeout, 
       ROS_ERROR_STREAM_NAMED("LibModbusClient", "Could not establish modbus connection. Cable connected?");
       return false;
     }
-    usleep(timeout);  // wait "timout" usec
+    std::this_thread::sleep_for(std::chrono::duration<double>(timeout));
   }
   ::close(sockfd);
-  sleep(1);  // wait one second to grant a free port
+  std::this_thread::sleep_for(std::chrono::duration<double>(1));  // wait one second to grant a free port
 
   return true;
 }

--- a/prbt_hardware_support/src/libmodbus_client.cpp
+++ b/prbt_hardware_support/src/libmodbus_client.cpp
@@ -55,10 +55,13 @@ bool LibModbusClient::init(const char* ip, unsigned int port)
 
   if (modbus_connect(modbus_connection_) == -1)
   {
+    // LCOV_EXCL_START the following lines are hard to cover since the above checkIPConnection should prevent
+    // exactly this situation
     ROS_ERROR_STREAM_NAMED("LibModbusClient", "Could not establish modbus connection." << modbus_strerror(errno));
     modbus_free(modbus_connection_);
     modbus_connection_ = nullptr;
     return false;
+    // LCOV_EXCL_STOP
   }
 
   return true;

--- a/prbt_hardware_support/src/pilz_modbus_client.cpp
+++ b/prbt_hardware_support/src/pilz_modbus_client.cpp
@@ -47,7 +47,7 @@ bool PilzModbusClient::init(const char* ip, unsigned int port, unsigned int retr
       return true;
     }
 
-    ROS_ERROR_STREAM("Connection to " << ip << ":" << port << " failed. Try(" << retry_n + 1 << "/" << retries << ")");
+    ROS_WARN_STREAM("Connection to " << ip << ":" << port << " failed. Try(" << retry_n + 1 << "/" << retries << ")");
 
     if (!ros::ok())
     {
@@ -71,7 +71,7 @@ bool PilzModbusClient::init(const char* ip, unsigned int port)
 
   if (!modbus_client_->init(ip, port))
   {
-    ROS_ERROR("Init failed");
+    ROS_DEBUG("Init failed");
     state_ = State::not_initialized;
     return false;
   }

--- a/prbt_hardware_support/src/pilz_modbus_client.cpp
+++ b/prbt_hardware_support/src/pilz_modbus_client.cpp
@@ -44,6 +44,9 @@ bool PilzModbusClient::init(const char* ip, unsigned int port, unsigned int retr
   {
     if (init(ip, port))
     {
+      // The following warning needs only to be shown to complete the warnings shown if this didn't work on the first
+      // try
+      ROS_WARN_STREAM_COND(retry_n > 1, "Connection to " << ip << ":" << port << " successful.");
       return true;
     }
 

--- a/prbt_hardware_support/src/pilz_modbus_client_node.cpp
+++ b/prbt_hardware_support/src/pilz_modbus_client_node.cpp
@@ -122,7 +122,11 @@ int main(int argc, char** argv)
   // LCOV_EXCL_START inside this main ignored, tested multiple times in the unittest
   if (!res)
   {
-    ROS_ERROR_STREAM("Connection to modbus server " << ip << ":" << port << " could not be established");
+    ROS_ERROR_STREAM("Could not establish modbus connection with: "
+                     << ip << ":" << port
+                     << ". Make sure that your cables are connected properly and that "
+                        "you have set the right IP Address and Port");
+
     return EXIT_FAILURE;
   }
 

--- a/prbt_hardware_support/src/pilz_modbus_client_node.cpp
+++ b/prbt_hardware_support/src/pilz_modbus_client_node.cpp
@@ -125,7 +125,7 @@ int main(int argc, char** argv)
     ROS_ERROR_STREAM("Could not establish modbus connection with: "
                      << ip << ":" << port
                      << ". Make sure that your cables are connected properly and that "
-                        "you have set the right IP Address and Port");
+                        "you have set the correct ip address and port.");
 
     return EXIT_FAILURE;
   }

--- a/prbt_hardware_support/test/unit_tests/unittest_libmodbus_client.cpp
+++ b/prbt_hardware_support/test/unit_tests/unittest_libmodbus_client.cpp
@@ -321,33 +321,34 @@ TEST_F(LibModbusClientTest, setResponseTimeout)
   client.close();
 }
 
-/**
- * @brief Tests that the checkIPConnection function will respond properly on presense of a modbus server and also if it
- * misses.
- *
- * @note To keep things simple timeout and repeats are not altered.
- */
-TEST_F(LibModbusClientTest, checkIPConnection)
-{
-  EXPECT_FALSE(checkIPConnection(LOCALHOST, testPort(), 0.1, 20));  // No Server
+// /**
+//  * @brief Tests that the checkIPConnection function will respond properly on presense of a modbus server and also if
+//  it
+//  * misses.
+//  *
+//  * @note To keep things simple timeout and repeats are not altered.
+//  */
+// TEST_F(LibModbusClientTest, checkIPConnection)
+// {
+//   EXPECT_FALSE(checkIPConnection(LOCALHOST, testPort(), 0.1, 20));  // No Server
 
-  LibModbusClient client;
-  std::shared_ptr<PilzModbusServerMock> server(new PilzModbusServerMock(DEFAULT_REGISTER_SIZE));
-  server->startAsync(LOCALHOST, testPort());
+//   LibModbusClient client;
+//   std::shared_ptr<PilzModbusServerMock> server(new PilzModbusServerMock(DEFAULT_REGISTER_SIZE));
+//   server->startAsync(LOCALHOST, testPort());
 
-  EXPECT_TRUE(client.init(LOCALHOST, testPort()));  // Server present
+//   EXPECT_TRUE(client.init(LOCALHOST, testPort()));  // Server present
 
-  EXPECT_TRUE(checkIPConnection(LOCALHOST, testPort(), 0.1, 20));  // Server present ip+port correct
+//   EXPECT_TRUE(checkIPConnection(LOCALHOST, testPort(), 0.1, 20));  // Server present ip+port correct
 
-  EXPECT_FALSE(checkIPConnection(LOCALHOST, 4711, 0.1, 20));  // Server present ip correct port wrong
+//   EXPECT_FALSE(checkIPConnection(LOCALHOST, 4711, 0.1, 20));  // Server present ip correct port wrong
 
-  EXPECT_FALSE(checkIPConnection("192.192.192.192", testPort(), 0.1, 20));  // Server present ip wrong port correct
+//   EXPECT_FALSE(checkIPConnection("192.192.192.192", testPort(), 0.1, 20));  // Server present ip wrong port correct
 
-  EXPECT_FALSE(checkIPConnection("192.192.192.192", 4711, 0.1, 20));  // Server present ip wrong port wrong
+//   EXPECT_FALSE(checkIPConnection("192.192.192.192", 4711, 0.1, 20));  // Server present ip wrong port wrong
 
-  shutdownModbusServer(server.get(), client);
-  client.close();
-}
+//   shutdownModbusServer(server.get(), client);
+//   client.close();
+// }
 
 }  // namespace pilz_modbus_client_test
 

--- a/prbt_hardware_support/test/unit_tests/unittest_libmodbus_client.cpp
+++ b/prbt_hardware_support/test/unit_tests/unittest_libmodbus_client.cpp
@@ -323,7 +323,13 @@ TEST_F(LibModbusClientTest, setResponseTimeout)
   client.close();
 }
 
+TEST_F(LibModbusClientTest, checkIPConnection)
+{
+  EXPECT_FALSE(checkIPConnection("192.192.192.192", 4711, 100000, 20));
+}
+
 }  // namespace pilz_modbus_client_test
+
 
 int main(int argc, char* argv[])
 {

--- a/prbt_hardware_support/test/unit_tests/unittest_libmodbus_client.cpp
+++ b/prbt_hardware_support/test/unit_tests/unittest_libmodbus_client.cpp
@@ -328,27 +328,26 @@ TEST_F(LibModbusClientTest, setResponseTimeout)
 //  *
 //  * @note To keep things simple timeout and repeats are not altered.
 //  */
-// TEST_F(LibModbusClientTest, checkIPConnection)
-// {
-//   EXPECT_FALSE(checkIPConnection(LOCALHOST, testPort(), 0.1, 20));  // No Server
+TEST_F(LibModbusClientTest, checkIPConnection)
+{
+  EXPECT_FALSE(checkIPConnection(LOCALHOST, testPort()));  // No Server
 
-//   LibModbusClient client;
-//   std::shared_ptr<PilzModbusServerMock> server(new PilzModbusServerMock(DEFAULT_REGISTER_SIZE));
-//   server->startAsync(LOCALHOST, testPort());
+  LibModbusClient client;
+  std::shared_ptr<PilzModbusServerMock> server(new PilzModbusServerMock(DEFAULT_REGISTER_SIZE));
+  server->startAsync(LOCALHOST, testPort());
+  EXPECT_TRUE(client.init(LOCALHOST, testPort()));  // Server present
 
-//   EXPECT_TRUE(client.init(LOCALHOST, testPort()));  // Server present
+  EXPECT_TRUE(checkIPConnection(LOCALHOST, testPort()));  // Server present ip+port correct
 
-//   EXPECT_TRUE(checkIPConnection(LOCALHOST, testPort(), 0.1, 20));  // Server present ip+port correct
+  EXPECT_FALSE(checkIPConnection(LOCALHOST, 4711));  // Server present ip correct port wrong
 
-//   EXPECT_FALSE(checkIPConnection(LOCALHOST, 4711, 0.1, 20));  // Server present ip correct port wrong
+  EXPECT_FALSE(checkIPConnection("192.192.192.192", testPort()));  // Server present ip wrong port correct
 
-//   EXPECT_FALSE(checkIPConnection("192.192.192.192", testPort(), 0.1, 20));  // Server present ip wrong port correct
+  EXPECT_FALSE(checkIPConnection("192.192.192.192", 4711));  // Server present ip wrong port wrong
 
-//   EXPECT_FALSE(checkIPConnection("192.192.192.192", 4711, 0.1, 20));  // Server present ip wrong port wrong
-
-//   shutdownModbusServer(server.get(), client);
-//   client.close();
-// }
+  shutdownModbusServer(server.get(), client);
+  client.close();
+}
 
 }  // namespace pilz_modbus_client_test
 

--- a/prbt_hardware_support/test/unit_tests/unittest_libmodbus_client.cpp
+++ b/prbt_hardware_support/test/unit_tests/unittest_libmodbus_client.cpp
@@ -329,7 +329,7 @@ TEST_F(LibModbusClientTest, setResponseTimeout)
  */
 TEST_F(LibModbusClientTest, checkIPConnection)
 {
-  EXPECT_FALSE(checkIPConnection(LOCALHOST, testPort(), 100000, 20));  // No Server
+  EXPECT_FALSE(checkIPConnection(LOCALHOST, testPort(), 0.1, 20));  // No Server
 
   LibModbusClient client;
   std::shared_ptr<PilzModbusServerMock> server(new PilzModbusServerMock(DEFAULT_REGISTER_SIZE));
@@ -337,13 +337,13 @@ TEST_F(LibModbusClientTest, checkIPConnection)
 
   EXPECT_TRUE(client.init(LOCALHOST, testPort()));  // Server present
 
-  EXPECT_TRUE(checkIPConnection(LOCALHOST, testPort(), 100000, 20));  // Server present ip+port correct
+  EXPECT_TRUE(checkIPConnection(LOCALHOST, testPort(), 0.1, 20));  // Server present ip+port correct
 
-  EXPECT_FALSE(checkIPConnection(LOCALHOST, 4711, 100000, 20));  // Server present ip correct port wrong
+  EXPECT_FALSE(checkIPConnection(LOCALHOST, 4711, 0.1, 20));  // Server present ip correct port wrong
 
-  EXPECT_FALSE(checkIPConnection("192.192.192.192", testPort(), 100000, 20));  // Server present ip wrong port correct
+  EXPECT_FALSE(checkIPConnection("192.192.192.192", testPort(), 0.1, 20));  // Server present ip wrong port correct
 
-  EXPECT_FALSE(checkIPConnection("192.192.192.192", 4711, 100000, 20));  // Server present ip wrong port wrong
+  EXPECT_FALSE(checkIPConnection("192.192.192.192", 4711, 0.1, 20));  // Server present ip wrong port wrong
 
   shutdownModbusServer(server.get(), client);
   client.close();

--- a/prbt_hardware_support/test/unit_tests/unittest_libmodbus_client.cpp
+++ b/prbt_hardware_support/test/unit_tests/unittest_libmodbus_client.cpp
@@ -344,6 +344,8 @@ TEST_F(LibModbusClientTest, checkIPConnection)
 
   EXPECT_FALSE(checkIPConnection("192.192.192.192", testPort()));  // Server present ip wrong port correct
 
+  unsigned int wrong_port = 4711;
+  ASSERT_NE(wrong_port, testPort());
   EXPECT_FALSE(checkIPConnection("192.192.192.192", 4711));  // Server present ip wrong port wrong
 
   shutdownModbusServer(server.get(), client);

--- a/prbt_hardware_support/test/unit_tests/unittest_libmodbus_client.cpp
+++ b/prbt_hardware_support/test/unit_tests/unittest_libmodbus_client.cpp
@@ -335,7 +335,8 @@ TEST_F(LibModbusClientTest, checkIPConnection)
   LibModbusClient client;
   std::shared_ptr<PilzModbusServerMock> server(new PilzModbusServerMock(DEFAULT_REGISTER_SIZE));
   server->startAsync(LOCALHOST, testPort());
-  EXPECT_TRUE(client.init(LOCALHOST, testPort()));  // Server present
+  EXPECT_TRUE(client.init(LOCALHOST, testPort()));  // Needed to make sure server is actually present. (Not optimal,
+                                                    // needs adaption inside the server mock)
 
   EXPECT_TRUE(checkIPConnection(LOCALHOST, testPort()));  // Server present ip+port correct
 


### PR DESCRIPTION
Changes in Constructor of class LibModbusClient in libmodbus_client.cpp. 
Before a modbus connection is established a dummy TCP connection is made with a zero timeout. This is repeated 15 times every 100ms until success. If connection attempt was successful the connection is closed. If it was not successful the constructor returns false.  