### PR TITLE
Add missing header to pilz_testutils

### DIFF
--- a/pilz_testutils/CMakeLists.txt
+++ b/pilz_testutils/CMakeLists.txt
@@ -11,6 +11,7 @@ add_definitions(-Werror)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   pilz_utils
+  sensor_msgs
 )
 
 ###################################

--- a/pilz_testutils/package.xml
+++ b/pilz_testutils/package.xml
@@ -19,4 +19,5 @@
 
   <build_depend>roscpp</build_depend>
   <build_depend>pilz_utils</build_depend>
+  <build_depend>sensor_msgs</build_depend>
 </package>


### PR DESCRIPTION
Should fix 
http://build.ros.org/job/Mbin_uB64__pilz_testutils__ubuntu_bionic_amd64__binary/22/

Release needed after this.