### PR TITLE
Remove unnecessary include in joint_state_publisher_mock.cpp

### DIFF
--- a/pilz_testutils/src/joint_state_publisher_mock.cpp
+++ b/pilz_testutils/src/joint_state_publisher_mock.cpp
@@ -15,20 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <mutex>
-#include <string>
-#include <thread>
-#include <vector>
-
-#include <gmock/gmock.h>
-
-#include <ros/ros.h>
-
-#include <sensor_msgs/JointState.h>
+#include <pilz_testutils/joint_state_publisher_mock.h>
 
 #include <pilz_utils/get_param.h>
-
-#include <pilz_testutils/joint_state_publisher_mock.h>
 
 namespace pilz_testutils
 {


### PR DESCRIPTION
Triggered by issue #415, I looked at the `joint_state_publisher_mock.cpp` and couldn't find a reason why the `#include <gmock/gmock.h>` exists. To solve issue #415, I suggest to simply remove the include and all other unnecessary includes.