### PR TITLE
Add gmock and gtest dependencies to library target

### DIFF
--- a/pilz_testutils/CMakeLists.txt
+++ b/pilz_testutils/CMakeLists.txt
@@ -39,6 +39,38 @@ if(CATKIN_ENABLE_CLANG_TIDY)
   endif()
 endif()
 
+##########################
+## Function definition ##
+#########################
+
+function(_catkin_add_library_gmock target)
+  if(NOT $GMOCK_FOUND AND NOT GMOCK_FROM_SOURCE_FOUND)
+    message(WARNING "skipping GMOCK '${target}' in project '${PROJECT_NAME}' because GMOCK was not found")
+    return()
+  endif()
+
+  if(NOT DEFINED CMAKE_RUNTIME_OUTPUT_DIRECTORY)
+    message(FATAL_ERROR "_catkin_add_library_gmock() must be called after catkin_package() so that default output directories for the libraries are defined")
+  endif()
+
+  cmake_parse_arguments(ARG "EXCLUDE_FROM_ALL" "" "" ${ARGN})
+
+  list(APPEND GMOCK_INCLUDE_DIRS ${GTEST_INCLUDE_DIRS})
+  list(APPEND GMOCK_LIBRARY_DIRS ${GTEST_LIBRARY_DIRS})
+  list(APPEND GMOCK_LIBRARIES ${GTEST_LIBRARIES})
+
+  # create the executable, with basic + gtest/gmock build flags
+  include_directories(${GMOCK_INCLUDE_DIRS})
+  link_directories(${GMOCK_LIBRARY_DIRS})
+  add_library(${target} ${ARG_UNPARSED_ARGUMENTS})
+  if(ARG_EXCLUDE_FROM_ALL)
+    set_target_properties(${target} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+  endif()
+
+  assert(GMOCK_LIBRARIES)
+  target_link_libraries(${target} ${GMOCK_LIBRARIES})
+endfunction()
+
 ###########
 ## Build ##
 ###########
@@ -51,7 +83,7 @@ include_directories(
 )
 
 ## Declare a C++ library
-add_library(${PROJECT_NAME}
+_catkin_add_library_gmock(${PROJECT_NAME}
   src/async_test.cpp
   src/joint_state_publisher_mock.cpp
 )


### PR DESCRIPTION
Currently, the library target in [pilz_testutils/CMakeLists.txt](https://github.com/PilzDE/pilz_robots/blob/d7fa0f1a9244c7380203c187b311960d2edc9214/pilz_testutils/CMakeLists.txt#L54) is missing the gtest and gmock dependencies which causes build errors at some machines (see issue #415).
This PR tries to remedy the problems caused by the missing dependencies. 

**Note:**
The PR is based on the catkin cmake target [_catkin_add_executable_with_google_test()](https://github.com/ros/catkin/blob/afb0e2a2ae8c0c34c17a2df7b8e1219792246bf1/cmake/test/gtest.cmake#L154) from ROS.
Maybe in the future we can open a PR adding the newly introduced cmake function  `_catkin_add_library_gmock()` to the  catkin repo.