### PR TITLE
Use travis default dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: generic
-dist: trusty
 os: linux
 
 cache:


### PR DESCRIPTION
See https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment
and the example at https://github.com/ros-industrial/industrial_ci