### PR TITLE
Apply necessary PILZ test facility changes

### DIFF
--- a/prbt_hardware_support/include/prbt_hardware_support/modbus_api_definitions.h
+++ b/prbt_hardware_support/include/prbt_hardware_support/modbus_api_definitions.h
@@ -26,7 +26,7 @@ namespace modbus_api
 {
 namespace v3
 {
-static constexpr uint16_t MODBUS_API_VERSION_REQUIRED{ 3 };
+static constexpr uint16_t MODBUS_API_VERSION_REQUIRED{ 2 };
 
 static constexpr uint16_t MODBUS_BRAKE_TEST_PASSED{ 2 };
 static constexpr uint16_t MODBUS_BRAKE_TEST_NOT_PASSED{ 1 };

--- a/prbt_hardware_support/src/pilz_modbus_client_node.cpp
+++ b/prbt_hardware_support/src/pilz_modbus_client_node.cpp
@@ -31,7 +31,7 @@
 
 static constexpr int32_t MODBUS_CONNECTION_RETRIES_DEFAULT{ -1 };
 static constexpr double MODBUS_CONNECTION_RETRY_TIMEOUT_S_DEFAULT{ 1.0 };
-static constexpr int MODBUS_RESPONSE_TIMEOUT_MS{ 20 };
+static constexpr int MODBUS_RESPONSE_TIMEOUT_MS{ 500 };
 
 using namespace prbt_hardware_support;
 

--- a/prbt_support/launch/robot.launch
+++ b/prbt_support/launch/robot.launch
@@ -12,7 +12,7 @@
   <arg name="safety_hw" default="pss4000"/>
   <arg name="read_api_spec_file" default="$(find prbt_hardware_support)/config/modbus_read_api_spec_$(arg safety_hw).yaml" />
   <arg name="write_api_spec_file" default="$(find prbt_hardware_support)/config/modbus_write_api_spec_$(arg safety_hw).yaml" />
-  <arg name="modbus_server_ip" default="$(eval '192.168.0.10' if safety_hw=='pss4000' else '169.254.60.1')" />
+  <arg name="modbus_server_ip" default="$(eval '169.254.60.9' if safety_hw=='pss4000' else '169.254.60.1')" />
 
   <!-- Options to enable and disable different hardware aspects -->
   <!-- These arguments have no effect if iso10218_support is false -->


### PR DESCRIPTION
This PR shows the changes, currently necessary to use the PILZ test facility. If re-based regularly, it can be used to simplify the set-up phase of the PILZ test facility.

**Note:**
This PR is not intended to be merged, it simply exists to simplify the set-up phase of the PILZ test facility.