### PR TITLE
[pilz_status_indicator_rqt:] Hide currently unsupported ui elements. Fixes #435

### DIFF
--- a/pilz_status_indicator_rqt/CHANGELOG.rst
+++ b/pilz_status_indicator_rqt/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package pilz_status_indicator_rqt
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Hide currently unsupported ui elements
+* Contributors: Pilz GmbH and Co. KG
+
 0.5.18 (2020-07-02)
 -------------------
 

--- a/pilz_status_indicator_rqt/src/pilz_status_indicator_rqt/status_indicator.py
+++ b/pilz_status_indicator_rqt/src/pilz_status_indicator_rqt/status_indicator.py
@@ -40,6 +40,13 @@ class PilzStatusIndicatorRqt(Plugin):
         self.setObjectName('PilzStatusIndicatorRqt')
         self._widget = PilzStatusIndicatorWidget(context.serial_number())
 
+        # Hide currently unsupported elements
+        self._widget.labelHW.hide()
+        self._widget.labelHW_.hide()
+        self._widget.labelROS.hide()
+        self._widget.labelROS_.hide()
+        self._widget.barSpeed.hide()
+
         # Set initial widget state
         self._widget.set_ROS_status(False)
         self._widget.set_HW_status(False)


### PR DESCRIPTION
Snapshot:

![status_indicator_elements_hidden](https://user-images.githubusercontent.com/35950815/87676652-28574680-c779-11ea-932a-03aaab8a1b93.png)
