### PR TITLE
Reduce planning context to urdf model in urdf_tests.test

### DIFF
--- a/prbt_support/test/urdf_tests.cpp
+++ b/prbt_support/test/urdf_tests.cpp
@@ -69,10 +69,10 @@ protected:
 protected:
   // ros stuff
   ros::NodeHandle ph_{ "~" };
-  robot_model::RobotModelConstPtr robot_model_{ robot_model_loader::RobotModelLoader(GetParam()).getModel() };
+  robot_model::RobotModelConstPtr robot_model_{ robot_model_loader::RobotModelLoader(GetParam(), false).getModel() };
 
   // parameters
-  std::string group_name_, tip_link_name_;
+  std::string tip_link_name_;
 
   // test data
   std::vector<TestDataPoint> testDataSet_;
@@ -81,7 +81,6 @@ protected:
 void URDFKinematicsTest::SetUp()
 {
   // get necessary parameters
-  ASSERT_TRUE(ph_.getParam(ARM_GROUP_NAME, group_name_));
   ASSERT_TRUE(ph_.getParam(ARM_GROUP_TIP_LINK_NAME, tip_link_name_));
 
   // Fill the testdata
@@ -127,8 +126,7 @@ TEST_P(URDFKinematicsTest, forwardKinematics)
     Eigen::Vector3d pos_exp = getPos(test_data);
 
     // get frame transform
-    rstate.setJointGroupPositions(group_name_, joints);
-    // rstate.setVariablePositions(joints);
+    rstate.setVariablePositions(joints);
     rstate.update();
     Eigen::Affine3d transform = rstate.getFrameTransform(tip_link_name_);
 

--- a/prbt_support/test/urdf_tests.cpp
+++ b/prbt_support/test/urdf_tests.cpp
@@ -69,6 +69,8 @@ protected:
 protected:
   // ros stuff
   ros::NodeHandle ph_{ "~" };
+  // The following call to RobotModelLoader will throw an error message about not not finding srdf,
+  // but it works just fine with just urdf.
   robot_model::RobotModelConstPtr robot_model_{ robot_model_loader::RobotModelLoader(GetParam(), false).getModel() };
 
   // parameters

--- a/prbt_support/test/urdf_tests.test
+++ b/prbt_support/test/urdf_tests.test
@@ -16,13 +16,12 @@ limitations under the License.
 
 <launch>
 
-    <!-- load test parameters-->
-    <include file="$(find prbt_moveit_config)/launch/planning_context.launch" />
+  <!-- Load universal robot description format (URDF) -->
+  <param name="robot_description" command="$(find xacro)/xacro --inorder $(find prbt_support)/urdf/prbt.xacro"/>
 
-    <!-- run test -->
-    <test pkg="prbt_support" test-name="urdf_tests" type="urdf_tests" >
-        <param name="arm_group_name" value="manipulator" />
-        <param name="arm_tip_link" value="prbt_flange" />
-    </test>
+  <!-- run test -->
+  <test pkg="prbt_support" test-name="urdf_tests" type="urdf_tests" >
+    <param name="arm_tip_link" value="prbt_flange" />
+  </test>
 
 </launch>


### PR DESCRIPTION
Fixes #449 

Open issue of this ansatz: Loading a robot model without srdf leads to an error:
```
[ERROR] [1596483123.752162225]: Robot semantic description not found. Did you forget to define or remap '/robot_description_semantic'?
```