### PR TITLE
Fix catkin_lint errors

### DIFF
--- a/prbt_hardware_support/CMakeLists.txt
+++ b/prbt_hardware_support/CMakeLists.txt
@@ -59,7 +59,7 @@ generate_dynamic_reconfigure_options(
 ###################################
 catkin_package(
   INCLUDE_DIRS include
-  CATKIN_DEPENDS message_runtime std_msgs std_srvs sensor_msgs
+  CATKIN_DEPENDS message_runtime pilz_msgs roscpp std_msgs std_srvs sensor_msgs
 )
 
 ################


### PR DESCRIPTION
These errors appeared only after a newer catkin_lint version was used by industrial_ci