### PR TITLE
Fix wrong include for logger mock

### DIFF
--- a/pilz_control/test/unittest_pilz_joint_trajectory_controller.cpp
+++ b/pilz_control/test/unittest_pilz_joint_trajectory_controller.cpp
@@ -23,7 +23,6 @@
 #include <gmock/gmock.h>
 
 #include <pilz_testutils/async_test.h>
-#include <pilz_testutils/mock_appender.h>
 #include <pilz_testutils/logger_mock.h>
 
 #include <ros/ros.h>

--- a/pilz_testutils/include/pilz_testutils/logger_mock.h
+++ b/pilz_testutils/include/pilz_testutils/logger_mock.h
@@ -20,7 +20,7 @@
 
 #include <log4cxx/logger.h>
 
-#include <pilz_testutils/logger_mock.h>
+#include <pilz_testutils/mock_appender.h>
 
 namespace pilz_testutils
 {


### PR DESCRIPTION
`logger_mock.h` did not include `mock_appender.h` but itself(?!)

Thus user had to include both headers in order to use the LoggerMock.

