### PR TITLE
Fix update routine for unittest of PilzJointTrajectoryController

### DIFF
--- a/pilz_control/CHANGELOG.rst
+++ b/pilz_control/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package pilz_control
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Fix unittest of PilzJointTrajectoryController
+* Contributors: Pilz GmbH and Co. KG
+
 0.5.21 (2020-11-23)
 -------------------
 

--- a/pilz_control/test/pjtc_manager_mock.h
+++ b/pilz_control/test/pjtc_manager_mock.h
@@ -69,6 +69,7 @@ private:
   ros::NodeHandle nh_{ "~" };
   std::string controller_ns_;
   ros::Time last_update_time_;
+  ros::Duration last_period_;
   hardware_interface::RobotHW* hardware_;
 };
 
@@ -105,14 +106,15 @@ template <class SegmentImpl, class HWInterface>
 void PJTCManagerMock<SegmentImpl, HWInterface>::update()
 {
   ros::Time current_time{ ros::Time::now() };
-  controller_->update(current_time, current_time - last_update_time_);
+  last_period_ = current_time - last_update_time_;
   last_update_time_ = current_time;
+  controller_->update(last_update_time_, last_period_);
 }
 
 template <class SegmentImpl, class HWInterface>
 ros::Duration PJTCManagerMock<SegmentImpl, HWInterface>::getCurrentPeriod()
 {
-  return ros::Time::now() - last_update_time_;
+  return last_period_;
 }
 
 template <class SegmentImpl, class HWInterface>

--- a/pilz_control/test/robot_mock.h
+++ b/pilz_control/test/robot_mock.h
@@ -25,7 +25,7 @@
 
 constexpr unsigned int NUM_JOINTS{ 2 };
 constexpr std::array<const char*, NUM_JOINTS> JOINT_NAMES = { "shoulder_to_right_arm", "shoulder_to_left_arm" };
-constexpr double JOINT_VELOCITY_EPS{ 0.001 };
+constexpr double JOINT_VELOCITY_EPS{ 0.0001 };
 
 struct JointData
 {

--- a/pilz_control/test/unittest_pilz_joint_trajectory_controller.cpp
+++ b/pilz_control/test/unittest_pilz_joint_trajectory_controller.cpp
@@ -395,8 +395,9 @@ TEST_F(PilzJointTrajectoryControllerTest, testTrajCommandExecution)
   trajectory_command_publisher.publish(goal.trajectory);
 
   ros::Duration observation_time = getGoalDuration(goal) + ros::Duration(DEFAULT_UPDATE_PERIOD_SEC);
-  EXPECT_FALSE(
-      updateUntilRobotMotion(&robot_driver_, std::chrono::milliseconds(observation_time.toNSec() * 1000000ll)));
+  EXPECT_FALSE(updateUntilRobotMotion(&robot_driver_));  // motion would not start before goal message is received
+  progressInTime(observation_time);
+  EXPECT_FALSE(updateUntilRobotMotion(&robot_driver_));  // at this time the goal would have been reached
   BARRIER({ LOG_MSG_RECEIVED_EVENT_WARN, LOG_MSG_RECEIVED_EVENT_INFO });
 }
 


### PR DESCRIPTION
Backport of resp. changes on `noetic-devel` included here b34ee072e7b9ae4d4a93f98a4e63ec0685397a4a.
I would close #469 since it is also affected by these changes.

DoD is skipped here because it is a simple backport.