### PR TITLE
Allow usage of deprecated pilz_command_planner

### DIFF
--- a/prbt_moveit_config/launch/pilz_command_planner_planning_pipeline.launch.xml
+++ b/prbt_moveit_config/launch/pilz_command_planner_planning_pipeline.launch.xml
@@ -1,7 +1,10 @@
 <launch>
+  <!-- DEPRECATION NOTE: This planner has been integrated into MoveIt.
+       Please consider using the pilz_industrial_motion_planner:
+       https://moveit.ros.org/documentation/planners/ -->
 
   <!-- Pilz Command Planner Plugin for MoveIt! -->
-  <arg name="planning_plugin" value="pilz_industrial_motion_planner::CommandPlanner" />
+  <arg name="planning_plugin" value="pilz::CommandPlanner" />
 
   <!-- The request adapters (plugins) used when planning.
        ORDER MATTERS -->


### PR DESCRIPTION
These changes are needed for https://github.com/PilzDE/pilz_industrial_motion/pull/347